### PR TITLE
Fix npm package badge link in README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# Contributing
+
+Pull requests are welcome!
+
+## Conventional Commits
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/) to automate versioning and changelog generation. Use the following prefixes in your commit messages:
+
+| Prefix | Version bump | Example |
+|---|---|---|
+| `fix: …` | patch (1.0.x) | `fix: correct cell resolution output` |
+| `feat: …` | minor (1.x.0) | `feat: add ISEA4T grid support` |
+| `feat!: …` / `fix!: …` | major (x.0.0) | `feat!: rename cellToChildren` |
+
+A release PR is opened automatically by the bot after commits land on `main`. Merging it creates the GitHub release and publishes to npm.
+
+## Development Setup
+
+### Prerequisites
+
+- [Node.js](https://nodejs.org/) 20+
+- [Yarn](https://yarnpkg.com/) (via corepack: `corepack enable`)
+- [Emscripten](https://emscripten.org/docs/getting_started/downloads.html)
+
+### Project Structure
+
+| Folder | Description |
+|---|---|
+| `src-cpp` | DGGRID C++ source (inspired by DGGRIDR) |
+| `src-ts` | TypeScript wrapper around the Emscripten output |
+| `lib-wasm` | JS/WASM output from Emscripten |
+| `lib-wasm-py` | Experimental Python wrapper build |
+| `tests` | JS unit tests |
+
+### Build
+
+```bash
+yarn install
+yarn build
+```
+
+This compiles the WASM via Emscripten and builds the TypeScript wrapper and bundles.
+
+### Test
+
+```bash
+yarn test
+```
+
+### Serve the Emscripten output (development only)
+
+```bash
+yarn serve
+```
+
+Opens the Emscripten default page — navigate to `libdggrid.html` to test the raw WASM. You can invoke functions directly:
+
+```js
+Module.DgGEO_to_SEQNUM(0, 0, 0, 4, 10, 'HEXAGON', 'ISEA', [0], [0])
+```

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -76,6 +76,7 @@ export default defineConfig({
       { text: 'Guide', link: '/getting-started' },
       { text: 'API', link: '/api/' },
       { text: 'Demo', link: '/demo' },
+      { text: 'Contributing', link: '/contributing' },
     ],
 
     sidebar: [
@@ -84,6 +85,12 @@ export default defineConfig({
         items: [
           { text: 'Getting Started', link: '/getting-started' },
           { text: 'Geometry Notes', link: '/getting-started#geometry-notes' },
+        ],
+      },
+      {
+        text: 'Project',
+        items: [
+          { text: 'Contributing', link: '/contributing' },
         ],
       },
       {

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,60 @@
+# Contributing
+
+Pull requests are welcome!
+
+## Conventional Commits
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/) to automate versioning and changelog generation. Use the following prefixes in your commit messages:
+
+| Prefix | Version bump | Example |
+|---|---|---|
+| `fix: …` | patch (1.0.x) | `fix: correct cell resolution output` |
+| `feat: …` | minor (1.x.0) | `feat: add ISEA4T grid support` |
+| `feat!: …` / `fix!: …` | major (x.0.0) | `feat!: rename cellToChildren` |
+
+A release PR is opened automatically by the bot after commits land on `main`. Merging it creates the GitHub release and publishes to npm.
+
+## Development Setup
+
+### Prerequisites
+
+- [Node.js](https://nodejs.org/) 20+
+- [Yarn](https://yarnpkg.com/) (via corepack: `corepack enable`)
+- [Emscripten](https://emscripten.org/docs/getting_started/downloads.html)
+
+### Project Structure
+
+| Folder | Description |
+|---|---|
+| `src-cpp` | DGGRID C++ source (inspired by DGGRIDR) |
+| `src-ts` | TypeScript wrapper around the Emscripten output |
+| `lib-wasm` | JS/WASM output from Emscripten |
+| `lib-wasm-py` | Experimental Python wrapper build |
+| `tests` | JS unit tests |
+
+### Build
+
+```bash
+yarn install
+yarn build
+```
+
+This compiles the WASM via Emscripten and builds the TypeScript wrapper and bundles.
+
+### Test
+
+```bash
+yarn test
+```
+
+### Serve the Emscripten output (development only)
+
+```bash
+yarn serve
+```
+
+Opens the Emscripten default page — navigate to `libdggrid.html` to test the raw WASM. You can invoke functions directly:
+
+```js
+Module.DgGEO_to_SEQNUM(0, 0, 0, 4, 10, 'HEXAGON', 'ISEA', [0], [0])
+```

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,8 @@ A wrapper for DGGRID in Web Assembly. Based on last DGGRID c++ library developed
 
 [![NPM Version](https://img.shields.io/npm/v/webdggrid?style=flat-square)](https://www.npmjs.com/package/webdggrid)
 [![Docs](https://img.shields.io/github/actions/workflow/status/am2222/webDggrid/deploy.yml?style=flat-square&label=docs)](https://am2222.github.io/webDggrid/)
-[![npm package](https://img.shields.io/github/actions/workflow/status/am2222/webDggrid/main.yml?style=flat-square&label=npm%20package)](https://github.com/am2222/webDggrid/actions/workflows/main.yml)
+[![CI](https://img.shields.io/github/actions/workflow/status/am2222/webDggrid/ci.yml?style=flat-square&label=ci)](https://github.com/am2222/webDggrid/actions/workflows/ci.yml)
+[![npm package](https://img.shields.io/github/actions/workflow/status/am2222/webDggrid/publish.yml?style=flat-square&label=publish)](https://github.com/am2222/webDggrid/actions/workflows/publish.yml)
 [![](https://data.jsdelivr.com/v1/package/npm/webdggrid/badge)](https://www.jsdelivr.com/package/npm/webdggrid)
 
 </div>
@@ -47,64 +48,16 @@ const seqNum = dggs.geoToSequenceNum([[0, 0]]);
 ```
 
 
-## Supported Functions
+## API
 
-**Grid Creation**
+`setDggs` · `getResolution` · `setResolution` · `geoToSequenceNum` · `sequenceNumToGeo` · `sequenceNumToGrid` · `sequenceNumToGridFeatureCollection` · `geoToGeo` · `cellAreaKM` · `cellDistKM` · `nCells`
 
-- [setDggs](https://am2222.github.io/webDggrid/api/classes/Webdggrid.html#setDggs)
-- [getResolution](https://am2222.github.io/webDggrid/api/classes/Webdggrid.html#getResolution)
-- [setResolution](https://am2222.github.io/webDggrid/api/classes/Webdggrid.html#setResolution)
+See the [full API reference](https://am2222.github.io/webDggrid/api/) for details and type signatures.
 
-**Grid Statistics**
+## Contributing & Development
 
-- [cellAreaKM](https://am2222.github.io/webDggrid/api/classes/Webdggrid.html#cellAreaKM)
-- [cellDistKM](https://am2222.github.io/webDggrid/api/classes/Webdggrid.html#cellDistKM)
-- [nCells](https://am2222.github.io/webDggrid/api/classes/Webdggrid.html#nCells)
-
-**Grid Conversions**
-
-- [geoToGeo](https://am2222.github.io/webDggrid/api/classes/Webdggrid.html#geoToGeo)
-- [geoToSequenceNum](https://am2222.github.io/webDggrid/api/classes/Webdggrid.html#geoToSequenceNum)
-- [sequenceNumToGeo](https://am2222.github.io/webDggrid/api/classes/Webdggrid.html#sequenceNumToGeo)
-- [sequenceNumToGridFeatureCollection](https://am2222.github.io/webDggrid/api/classes/Webdggrid.html#sequenceNumToGridFeatureCollection)
-- [sequenceNumToGrid](https://am2222.github.io/webDggrid/api/classes/Webdggrid.html#sequenceNumToGrid)
+See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions, project structure, and commit conventions.
 
 ## Changes
 
-Slow development pace.
-
-**1.0.5**
-
-- Added support to `SeqNumGrid`
-
-## Development
-
-Make sure to setup `emscripten` on your machine.
-
-The development process involves modifying the `cpp` code and use `utils/make.js` to build the library.
-
-| Folder   |      Desc       |
-|----------|:-------------:|
-| src-cpp|  The src file of the DGGRID. It is inspired from DGGRIDR project.|
-| src-ts|  The src file js wrapper around the `emscripten` code to make it easier to interact with library in more `js` friendly approach.|
-| lib-wasm |    The js output that `emscripten` generates    |
-| lib-wasm-py | experimental python wrapper  |
-| tests| JS unit tests  |
-
-To build the entire library simply run
-``yarn build``
-
-It will build webassembly file and also builds the typescript wrapper.
-
-### Server the emscripten output [just for development purpuse]
-
-Run the following command. It will open the emscripten's default page to test the wasm file. Just navigate to `libdggrid.html`
- `
-yarn serve
- `
-
- you can invoke the functions similar to
-
- ```
-Module.DgGEO_to_SEQNUM(0,0,0,4,10,'HEXAGON','ISEA',[0],[0])
- ``
+See [CHANGELOG.md](CHANGELOG.md) for the full history.


### PR DESCRIPTION
Update the npm package badge link in the README to point to the correct workflow. Additionally, add a contributing section to the documentation for better guidance on project contributions.