### PR TITLE
Update README badge links and rename WASM assets

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,14 +41,21 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Rename WASM assets to avoid name collisions
+        run: |
+          cp lib-wasm/libdggrid.js    lib-wasm-libdggrid.js
+          cp lib-wasm/libdggrid.wasm  lib-wasm-libdggrid.wasm
+          cp lib-wasm-py/libdggrid.js   lib-wasm-py-libdggrid.js
+          cp lib-wasm-py/libdggrid.wasm lib-wasm-py-libdggrid.wasm
+
       - name: Upload WASM assets to release
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            lib-wasm/libdggrid.js
-            lib-wasm/libdggrid.wasm
-            lib-wasm-py/libdggrid.js
-            lib-wasm-py/libdggrid.wasm
+            lib-wasm-libdggrid.js
+            lib-wasm-libdggrid.wasm
+            lib-wasm-py-libdggrid.js
+            lib-wasm-py-libdggrid.wasm
 
   deploy-docs:
     needs: build-publish-release

--- a/readme.md
+++ b/readme.md
@@ -6,10 +6,13 @@ A WebAssembly wrapper for [DGGRID](https://github.com/sahrk/DGGRID), the C++ lib
 <div align="center">
 
 [![NPM Version](https://img.shields.io/npm/v/webdggrid?style=flat-square)](https://www.npmjs.com/package/webdggrid)
-[![Docs](https://img.shields.io/github/actions/workflow/status/am2222/webDggrid/deploy.yml?style=flat-square&label=docs)](https://am2222.github.io/webDggrid/)
-[![CI](https://img.shields.io/github/actions/workflow/status/am2222/webDggrid/pr-check.yml?style=flat-square&label=ci)](https://github.com/am2222/webDggrid/actions/workflows/pr-check.yml)
-[![npm package](https://img.shields.io/github/actions/workflow/status/am2222/webDggrid/publish.yml?style=flat-square&label=publish)](https://github.com/am2222/webDggrid/actions/workflows/publish.yml)
-[![](https://data.jsdelivr.com/v1/package/npm/webdggrid/badge)](https://www.jsdelivr.com/package/npm/webdggrid)
+
+[![Docs](https://img.shields.io/github/actions/workflow/status/am2222/webDggrid/publish.yml?style=flat-square&label=docs)](https://am2222.github.io/webDggrid/)
+
+[![Tests](https://img.shields.io/github/actions/workflow/status/am2222/webDggrid/pr-check.yml?style=flat-square&label=ci)](https://github.com/am2222/webDggrid/actions/workflows/pr-check.yml)
+
+
+[![JS DEliver](https://data.jsdelivr.com/v1/package/npm/webdggrid/badge)](https://www.jsdelivr.com/package/npm/webdggrid)
 
 </div>
 


### PR DESCRIPTION
Correct badge links in the README for improved accuracy and rename WASM assets to prevent name collisions during uploads.