### PR TITLE
Add IGEO7/Z7 index support and integrate igeo7_duckdb submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "submodules/DGGRID"]
 	path = submodules/DGGRID
 	url = https://github.com/sahrk/DGGRID.git
+[submodule "submodules/igeo7_duckdb"]
+	path = submodules/igeo7_duckdb
+	url = https://github.com/allixender/igeo7_duckdb

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,13 @@ set(SHAPE_INC  "${DGGRID_DIR}/src/lib/shapelib/include/shapelib"
                "${DGGRID_DIR}/src/lib/shapelib/include")
 set(SHAPE_LIB  "${DGGRID_DIR}/src/lib/shapelib/lib")
 
+# ── IGEO7 / Z7 paths (from allixender/igeo7_duckdb submodule) ──────────────
+# We compile only the upstream Z7 C++ core — the DuckDB extension glue
+# (src/igeo7_extension.cpp) is intentionally excluded.
+set(IGEO7_DIR "${CMAKE_SOURCE_DIR}/submodules/igeo7_duckdb")
+set(IGEO7_Z7_INC "${IGEO7_DIR}/src")
+set(IGEO7_Z7_SOURCES "${IGEO7_DIR}/src/z7/library.cpp")
+
 # ── Source files ──────────────────────────────────────────────────────────
 file(GLOB DGLIB_SOURCES  "${DGLIB_LIB}/*.cpp")
 file(GLOB PROJ4_SOURCES  "${PROJ4_LIB}/*.cpp")
@@ -29,6 +36,7 @@ file(GLOB SHAPE_SOURCES  "${SHAPE_LIB}/*.c")
 set(WRAPPER_SOURCES
     "${CMAKE_SOURCE_DIR}/src-cpp/dggrid_transform.cpp"
     "${CMAKE_SOURCE_DIR}/src-cpp/webdggrid.cpp"
+    "${CMAKE_SOURCE_DIR}/src-cpp/igeo7_bindings.cpp"
 )
 
 # ── Target ────────────────────────────────────────────────────────────────
@@ -36,6 +44,7 @@ add_executable(libdggrid
     ${DGLIB_SOURCES}
     ${PROJ4_SOURCES}
     ${SHAPE_SOURCES}
+    ${IGEO7_Z7_SOURCES}
     ${WRAPPER_SOURCES}
 )
 
@@ -43,6 +52,7 @@ target_include_directories(libdggrid PRIVATE
     "${DGLIB_INC}"
     "${PROJ4_INC}"
     "${SHAPE_INC}"
+    "${IGEO7_Z7_INC}"
     "${CMAKE_SOURCE_DIR}/src-cpp"
 )
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -42,6 +42,7 @@ export default defineConfig({
           { text: 'Hierarchical Operations', link: '/hierarchical-operations' },
           { text: 'Hierarchical Address Types', link: '/hierarchical-addresses' },
           { text: 'Index Arithmetic', link: '/index-arithmetic' },
+          { text: 'IGEO7 / Z7 Index', link: '/igeo7' },
           { text: 'Multi-Aperture', link: '/multi-aperture' },
         ],
       },

--- a/docs/.vitepress/theme/components/Igeo7Demo.vue
+++ b/docs/.vitepress/theme/components/Igeo7Demo.vue
@@ -1,0 +1,439 @@
+<script setup>
+import { computed, onMounted, reactive, ref } from 'vue'
+import { loadWebdggrid } from '../utils/loadWebdggrid.js'
+
+const INVALID = 0xFFFFFFFFFFFFFFFFn
+
+const state = reactive({
+  ready: false,
+  loading: true,
+  error: null,
+  input: '0800432',
+  packed: null,
+})
+
+let dggs = null
+
+onMounted(async () => {
+  try {
+    const Webdggrid = await loadWebdggrid()
+    dggs = await Webdggrid.load()
+    state.ready = true
+    state.loading = false
+    parseInput()
+  } catch (e) {
+    state.error = e?.message ?? String(e)
+    state.loading = false
+  }
+})
+
+function parseInput() {
+  if (!dggs) return
+  state.error = null
+  try {
+    const s = state.input.trim()
+    if (!/^\d+$/.test(s) || s.length < 2) {
+      throw new Error('Enter a numeric Z7 string (2-digit base + digit chars), e.g. "0800432"')
+    }
+    const base = Number(s.slice(0, 2))
+    if (base < 0 || base > 11) {
+      throw new Error(`Base cell ${base} is out of range (must be 0-11)`)
+    }
+    if (s.length > 22) {
+      throw new Error('Z7 strings have at most 20 digits beyond the base')
+    }
+    state.packed = dggs.igeo7FromString(s)
+  } catch (e) {
+    state.packed = null
+    state.error = e?.message ?? String(e)
+  }
+}
+
+function selectExample(s) {
+  state.input = s
+  parseInput()
+}
+
+function loadFromPacked(idx) {
+  state.input = dggs.igeo7ToString(idx)
+  parseInput()
+}
+
+const baseCell = computed(() =>
+  state.packed != null ? dggs.igeo7GetBaseCell(state.packed) : null
+)
+const resolution = computed(() =>
+  state.packed != null ? dggs.igeo7GetResolution(state.packed) : null
+)
+const digits = computed(() => {
+  if (state.packed == null) return []
+  return Array.from({ length: 20 }, (_, i) => dggs.igeo7GetDigit(state.packed, i + 1))
+})
+const firstNonZero = computed(() =>
+  state.packed != null ? dggs.igeo7FirstNonZero(state.packed) : null
+)
+
+const parentChain = computed(() => {
+  if (state.packed == null) return []
+  const out = []
+  let cell = state.packed
+  while (true) {
+    out.push({
+      cell,
+      string: dggs.igeo7ToString(cell),
+      resolution: dggs.igeo7GetResolution(cell),
+    })
+    if (dggs.igeo7GetResolution(cell) === 0) break
+    cell = dggs.igeo7Parent(cell)
+  }
+  return out
+})
+
+const neighbours = computed(() => {
+  if (state.packed == null) return []
+  return dggs.igeo7Neighbours(state.packed).map((n, i) => ({
+    direction: i + 1,
+    cell: n,
+    valid: dggs.igeo7IsValid(n),
+    string: dggs.igeo7IsValid(n) ? dggs.igeo7ToString(n) : '—',
+  }))
+})
+
+const packedHex = computed(() => {
+  if (state.packed == null) return ''
+  return '0x' + state.packed.toString(16).toUpperCase().padStart(16, '0')
+})
+</script>
+
+<template>
+  <div class="igeo7-demo">
+    <div v-if="state.loading" class="status">Loading WebDggrid WASM…</div>
+    <div v-else-if="state.error && !state.ready" class="status error">
+      Failed to load: {{ state.error }}
+    </div>
+    <template v-else>
+      <div class="control-row">
+        <label>
+          <span class="label">Z7 string</span>
+          <input
+            v-model="state.input"
+            class="input"
+            spellcheck="false"
+            @input="parseInput"
+            @keydown.enter="parseInput"
+          />
+        </label>
+        <div class="examples">
+          <span class="label">Examples:</span>
+          <button
+            v-for="ex in ['0800432', '08', '0800', '11', '000161612062413', '07654321']"
+            :key="ex"
+            class="chip"
+            @click="selectExample(ex)"
+          >
+            {{ ex }}
+          </button>
+        </div>
+      </div>
+
+      <div v-if="state.error" class="status error">{{ state.error }}</div>
+
+      <div v-if="state.packed != null" class="grid">
+        <section class="card">
+          <h4>Decomposition</h4>
+          <table class="kv">
+            <tbody>
+              <tr><th>Compact</th><td><code>{{ dggs.igeo7ToString(state.packed) }}</code></td></tr>
+              <tr><th>Packed (decimal)</th><td><code>{{ state.packed.toString() }}n</code></td></tr>
+              <tr><th>Packed (hex)</th><td><code>{{ packedHex }}</code></td></tr>
+              <tr><th>Base cell</th><td>{{ baseCell }}</td></tr>
+              <tr><th>Resolution</th><td>{{ resolution }}</td></tr>
+              <tr><th>First non-zero digit</th><td>{{ firstNonZero }}</td></tr>
+            </tbody>
+          </table>
+
+          <h5>Digit slots (1-20)</h5>
+          <div class="digits">
+            <span
+              v-for="(d, i) in digits"
+              :key="i"
+              class="digit"
+              :class="{ padding: d === 7, leading: i + 1 < firstNonZero, active: i + 1 === firstNonZero }"
+              :title="`Position ${i + 1}` + (d === 7 ? ' (padding)' : '')"
+            >
+              <small>{{ i + 1 }}</small>
+              <strong>{{ d }}</strong>
+            </span>
+          </div>
+        </section>
+
+        <section class="card">
+          <h4>Parent chain (walk up to resolution 0)</h4>
+          <table class="rows">
+            <thead>
+              <tr><th>Step</th><th>Compact</th><th>Resolution</th><th></th></tr>
+            </thead>
+            <tbody>
+              <tr v-for="(row, i) in parentChain" :key="i" :class="{ self: i === 0 }">
+                <td>{{ i }}</td>
+                <td><code>{{ row.string }}</code></td>
+                <td>{{ row.resolution }}</td>
+                <td>
+                  <button v-if="i > 0" class="link-btn" @click="loadFromPacked(row.cell)">→ inspect</button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+
+        <section class="card">
+          <h4>Neighbours (6 GBT directions)</h4>
+          <table class="rows">
+            <thead>
+              <tr><th>Dir</th><th>Compact</th><th>Status</th><th></th></tr>
+            </thead>
+            <tbody>
+              <tr v-for="n in neighbours" :key="n.direction" :class="{ invalid: !n.valid }">
+                <td>{{ n.direction }}</td>
+                <td><code>{{ n.string }}</code></td>
+                <td>
+                  <span v-if="n.valid" class="badge ok">valid</span>
+                  <span v-else class="badge warn">excluded</span>
+                </td>
+                <td>
+                  <button v-if="n.valid" class="link-btn" @click="loadFromPacked(n.cell)">→ inspect</button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <p class="hint">
+            Excluded neighbours are <code>UINT64_MAX</code> — typically one direction
+            on the 12 pentagon base cells at low resolutions.
+          </p>
+        </section>
+      </div>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.igeo7-demo {
+  margin: 1.25rem 0;
+  font-size: 0.92rem;
+}
+
+.status {
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  background: var(--vp-c-bg-soft);
+  color: var(--vp-c-text-2);
+}
+.status.error {
+  background: var(--vp-c-warning-soft);
+  color: var(--vp-c-warning-1);
+  border: 1px solid var(--vp-c-warning-2);
+}
+
+.control-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+  padding: 1rem;
+  background: var(--vp-c-bg-soft);
+  border-radius: 8px;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.label {
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: var(--vp-c-text-2);
+}
+
+.input {
+  font-family: var(--vp-font-family-mono);
+  font-size: 1rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--vp-c-border);
+  border-radius: 6px;
+  background: var(--vp-c-bg);
+  color: var(--vp-c-text-1);
+  width: 100%;
+  box-sizing: border-box;
+}
+.input:focus {
+  outline: none;
+  border-color: var(--vp-c-brand-1);
+}
+
+.examples {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.4rem;
+}
+.chip {
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.85rem;
+  padding: 0.2rem 0.55rem;
+  border: 1px solid var(--vp-c-border);
+  border-radius: 999px;
+  background: var(--vp-c-bg);
+  color: var(--vp-c-text-1);
+  cursor: pointer;
+}
+.chip:hover {
+  border-color: var(--vp-c-brand-1);
+  color: var(--vp-c-brand-1);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+}
+@media (min-width: 900px) {
+  .grid {
+    grid-template-columns: 1fr 1fr;
+  }
+  .card:first-child {
+    grid-column: 1 / -1;
+  }
+}
+
+.card {
+  border: 1px solid var(--vp-c-border);
+  border-radius: 8px;
+  padding: 1rem;
+  background: var(--vp-c-bg);
+}
+.card h4 {
+  margin: 0 0 0.75rem 0;
+  font-size: 1rem;
+}
+.card h5 {
+  margin: 1rem 0 0.5rem 0;
+  font-size: 0.9rem;
+  color: var(--vp-c-text-2);
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.kv th,
+.kv td {
+  padding: 0.3rem 0.5rem;
+  text-align: left;
+  border-bottom: 1px solid var(--vp-c-divider);
+  vertical-align: top;
+}
+.kv th {
+  font-weight: 600;
+  color: var(--vp-c-text-2);
+  width: 40%;
+}
+.kv tr:last-child th,
+.kv tr:last-child td {
+  border-bottom: none;
+}
+
+.rows th,
+.rows td {
+  padding: 0.35rem 0.5rem;
+  text-align: left;
+  border-bottom: 1px solid var(--vp-c-divider);
+}
+.rows thead th {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--vp-c-text-2);
+  border-bottom: 2px solid var(--vp-c-divider);
+}
+.rows tr.self code { font-weight: 700; }
+.rows tr.invalid { opacity: 0.55; }
+
+.digits {
+  display: grid;
+  grid-template-columns: repeat(10, 1fr);
+  gap: 4px;
+}
+.digit {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 4px 2px;
+  border: 1px solid var(--vp-c-border);
+  border-radius: 4px;
+  font-family: var(--vp-font-family-mono);
+  background: var(--vp-c-bg-soft);
+}
+.digit small {
+  font-size: 0.65rem;
+  color: var(--vp-c-text-3);
+}
+.digit strong {
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+.digit.padding {
+  opacity: 0.35;
+}
+.digit.leading strong {
+  color: var(--vp-c-text-3);
+}
+.digit.active {
+  border-color: var(--vp-c-brand-1);
+  background: var(--vp-c-brand-soft);
+}
+.digit.active strong {
+  color: var(--vp-c-brand-1);
+}
+
+.badge {
+  display: inline-block;
+  padding: 0.1rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+.badge.ok {
+  background: var(--vp-c-tip-soft);
+  color: var(--vp-c-tip-1);
+}
+.badge.warn {
+  background: var(--vp-c-warning-soft);
+  color: var(--vp-c-warning-1);
+}
+
+.link-btn {
+  font-size: 0.8rem;
+  padding: 0.15rem 0.4rem;
+  border: 1px solid var(--vp-c-border);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--vp-c-brand-1);
+  cursor: pointer;
+}
+.link-btn:hover {
+  border-color: var(--vp-c-brand-1);
+  background: var(--vp-c-brand-soft);
+}
+
+.hint {
+  margin: 0.6rem 0 0 0;
+  font-size: 0.8rem;
+  color: var(--vp-c-text-2);
+}
+
+code {
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.88rem;
+}
+</style>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -5,6 +5,7 @@ import DggsD3Globe from './components/DggsD3Globe.vue'
 import DggsHeroBackground from './components/DggsHeroBackground.vue'
 import DggsAddressTypesDemo from './components/DggsAddressTypesDemo.vue'
 import DggsD3HierarchyDemo from './components/DggsD3HierarchyDemo.vue'
+import Igeo7Demo from './components/Igeo7Demo.vue'
 
 export default {
   extends: DefaultTheme,
@@ -15,6 +16,7 @@ export default {
     app.component('DggsHeroBackground', DggsHeroBackground)
     app.component('DggsAddressTypesDemo', DggsAddressTypesDemo)
     app.component('DggsD3HierarchyDemo', DggsD3HierarchyDemo)
+    app.component('Igeo7Demo', Igeo7Demo)
   },
 
   Layout() {

--- a/docs/api/_media/CHANGELOG.md
+++ b/docs/api/_media/CHANGELOG.md
@@ -1,5 +1,44 @@
 # Changelog
 
+## [1.7.0](https://github.com/am2222/webDggrid/compare/v1.6.0...v1.7.0) (2026-04-07)
+
+
+### Features
+
+* add sequenceNumAllParents method to retrieve all parent cells for given child cells ([7917cb4](https://github.com/am2222/webDggrid/commit/7917cb44f49dfd54c006cb0b682993cf9f954743))
+* optimize parent cell retrieval by converting child cell center to GEO and then to SEQNUM ([3579dfb](https://github.com/am2222/webDggrid/commit/3579dfb7e3c2bffc807aae448b47bef20e7b9865))
+
+## [1.6.0](https://github.com/am2222/webDggrid/compare/v1.5.0...v1.6.0) (2026-04-07)
+
+
+### Features
+
+* add cell index type selection and address conversion display in DGGs demo ([0863df8](https://github.com/am2222/webDggrid/commit/0863df8ccdd1579f92180e51f443be11a6713e55))
+* add DggsAddressTypesDemo component and integrate into documentation for address type conversions ([2f5821b](https://github.com/am2222/webDggrid/commit/2f5821bbc55cfb601e927eb774448818ff915a75))
+* add hierarchical address types and conversions ([e745d5a](https://github.com/am2222/webDggrid/commit/e745d5aa0fa0f6acb48e4f9929c7c253d449e5f4))
+* add hierarchy selection panel with index type and clear functionality ([380e8bc](https://github.com/am2222/webDggrid/commit/380e8bc45695c416ff6d3c6470f98613355fa6e6))
+* add Index Arithmetic documentation and link in the configuration ([1b111bb](https://github.com/am2222/webDggrid/commit/1b111bb76a7f92c22a210a62034b26b97629e955))
+* add methods for retrieving neighboring and hierarchical cells with comprehensive tests ([795f3a9](https://github.com/am2222/webDggrid/commit/795f3a9b33ff81e6beb4ff0a30a6bc336a279000))
+* add multi-aperture grid support with comprehensive documentation and examples ([ef72c0f](https://github.com/am2222/webDggrid/commit/ef72c0f6113e3dbf1eef4fa355468bbe10de21f7))
+* enhance child retrieval methods to support hexagonal grids and update related tests ([be5ab49](https://github.com/am2222/webDggrid/commit/be5ab49e790abe0fc1eab14635b27cb61e4c3df4))
+* enhance DGGs settings with dynamic controls and improved error handling ([0bedb7b](https://github.com/am2222/webDggrid/commit/0bedb7b2a03aa35534e43983457dcacab238c31b))
+* enhance hierarchy panel with improved layout and clear selection functionality ([100e444](https://github.com/am2222/webDggrid/commit/100e4444658ed54e2c1c737dfca7e8b00f4c6101))
+* enhance index digit manipulation methods and update documentation for Z3, Z7, and ZORDER ([f50f3f4](https://github.com/am2222/webDggrid/commit/f50f3f40befd48cf68128b88f5f1f1db271dc890))
+* enhance UI with theme-aware address highlighting and improve layout padding ([5384c1e](https://github.com/am2222/webDggrid/commit/5384c1eb8cd9a016b82f0a596746d4abbc2fae73))
+* implement Bitarithmetic demonstration with Z3 and Z7 arithmetic calculations ([4c6b180](https://github.com/am2222/webDggrid/commit/4c6b1803d6333f432107860429c9a733bd4c444d))
+* Implement bitwise operations for Z3, Z7, and ZORDER indices; add helper functions for digit manipulation and extraction ([e81ee6d](https://github.com/am2222/webDggrid/commit/e81ee6def3e910c6f554d37b94f52e088ae70014))
+* implement hierarchical address types (VERTEX2DD, ZORDER, Z3, Z7) with conversions and WASM bindings ([a01ee42](https://github.com/am2222/webDggrid/commit/a01ee42e248ecce0b2ca21295b8ac4b65d0bd6a7))
+* implement hierarchy layer removal and sanitize feature collections in DggsGlobe component ([83a37ad](https://github.com/am2222/webDggrid/commit/83a37ad02f8689ac02a7c0043a4170eb13037679))
+* implement loadWebdggrid utility for dynamic loading of Webdggrid class and update components to use it ([5a64660](https://github.com/am2222/webDggrid/commit/5a64660de1789d5b07cde9b5af0f0d1a5e7ad0f9))
+* update applySettings function to be asynchronous and ensure SVG rendering before processing ([1795816](https://github.com/am2222/webDggrid/commit/1795816cdeb40d5ae7b0314e000ace5a364468b3))
+* update documentation links and add geometry notes for pentagonal cells and antimeridian handling ([4767dd8](https://github.com/am2222/webDggrid/commit/4767dd867676f329a94df225806d5e0d24eb0c26))
+
+
+### Bug Fixes
+
+* ensure counts are converted to numbers in neighbor and child retrieval methods ([70f3fdb](https://github.com/am2222/webDggrid/commit/70f3fdbdb8ed4476a516efa51e379862b05734ff))
+* remove redundant styles from loadScript function in DggsAddressTypesDemo.vue ([396afd7](https://github.com/am2222/webDggrid/commit/396afd70d34dbf6cc5b7b8ae83aad1638b4d6bc3))
+
 ## [1.5.0](https://github.com/am2222/webDggrid/compare/v1.4.0...v1.5.0) (2026-04-04)
 
 

--- a/docs/api/classes/Webdggrid.md
+++ b/docs/api/classes/Webdggrid.md
@@ -2,7 +2,7 @@
 
 # Class: Webdggrid
 
-Defined in: [webdggrid.ts:252](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L252)
+Defined in: [webdggrid.ts:252](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L252)
 
 Main entry point for the WebDggrid library.
 
@@ -45,7 +45,7 @@ the returned instance throughout your application. Call
 
 > `protected` **\_module**: `any`
 
-Defined in: [webdggrid.ts:275](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L275)
+Defined in: [webdggrid.ts:275](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L275)
 
 ***
 
@@ -53,7 +53,7 @@ Defined in: [webdggrid.ts:275](https://github.com/am2222/webDggrid/blob/7917cb44
 
 > **dggs**: [`IDGGSProps`](../interfaces/IDGGSProps.md) = `DEFAULT_DGGS`
 
-Defined in: [webdggrid.ts:261](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L261)
+Defined in: [webdggrid.ts:261](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L261)
 
 The active DGGS configuration used by all conversion and statistics
 methods. Change it at any time via [setDggs](#setdggs).
@@ -67,7 +67,7 @@ pole at 0° N 0° E, azimuth 0°).
 
 > **resolution**: `number` = `DEFAULT_RESOLUTION`
 
-Defined in: [webdggrid.ts:273](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L273)
+Defined in: [webdggrid.ts:273](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L273)
 
 The active grid resolution. Higher values produce finer, smaller cells.
 The valid range depends on the aperture — for aperture 4 the practical
@@ -84,7 +84,7 @@ Defaults to `1`.
 
 > `readonly` `static` **Z3\_BITS\_PER\_DIGIT**: `2n` = `2n`
 
-Defined in: [webdggrid.ts:1571](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1571)
+Defined in: [webdggrid.ts:1571](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1571)
 
 **`Internal`**
 
@@ -94,7 +94,7 @@ Defined in: [webdggrid.ts:1571](https://github.com/am2222/webDggrid/blob/7917cb4
 
 > `readonly` `static` **Z3\_DIGIT\_MASK**: `3n` = `3n`
 
-Defined in: [webdggrid.ts:1572](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1572)
+Defined in: [webdggrid.ts:1572](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1572)
 
 **`Internal`**
 
@@ -104,7 +104,7 @@ Defined in: [webdggrid.ts:1572](https://github.com/am2222/webDggrid/blob/7917cb4
 
 > `readonly` `static` **Z3\_MAX\_RES**: `30` = `30`
 
-Defined in: [webdggrid.ts:1570](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1570)
+Defined in: [webdggrid.ts:1570](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1570)
 
 **`Internal`**
 
@@ -114,7 +114,7 @@ Defined in: [webdggrid.ts:1570](https://github.com/am2222/webDggrid/blob/7917cb4
 
 > `readonly` `static` **Z3\_QUAD\_MASK**: `17293822569102704640n` = `0xF000000000000000n`
 
-Defined in: [webdggrid.ts:1574](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1574)
+Defined in: [webdggrid.ts:1574](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1574)
 
 **`Internal`**
 
@@ -124,7 +124,7 @@ Defined in: [webdggrid.ts:1574](https://github.com/am2222/webDggrid/blob/7917cb4
 
 > `readonly` `static` **Z3\_QUAD\_OFFSET**: `60n` = `60n`
 
-Defined in: [webdggrid.ts:1573](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1573)
+Defined in: [webdggrid.ts:1573](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1573)
 
 **`Internal`**
 
@@ -134,7 +134,7 @@ Defined in: [webdggrid.ts:1573](https://github.com/am2222/webDggrid/blob/7917cb4
 
 > `readonly` `static` **Z7\_BITS\_PER\_DIGIT**: `3n` = `3n`
 
-Defined in: [webdggrid.ts:1564](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1564)
+Defined in: [webdggrid.ts:1564](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1564)
 
 **`Internal`**
 
@@ -144,7 +144,7 @@ Defined in: [webdggrid.ts:1564](https://github.com/am2222/webDggrid/blob/7917cb4
 
 > `readonly` `static` **Z7\_DIGIT\_MASK**: `7n` = `7n`
 
-Defined in: [webdggrid.ts:1565](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1565)
+Defined in: [webdggrid.ts:1565](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1565)
 
 **`Internal`**
 
@@ -154,7 +154,7 @@ Defined in: [webdggrid.ts:1565](https://github.com/am2222/webDggrid/blob/7917cb4
 
 > `readonly` `static` **Z7\_MAX\_RES**: `20` = `20`
 
-Defined in: [webdggrid.ts:1563](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1563)
+Defined in: [webdggrid.ts:1563](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1563)
 
 **`Internal`**
 
@@ -164,7 +164,7 @@ Defined in: [webdggrid.ts:1563](https://github.com/am2222/webDggrid/blob/7917cb4
 
 > `readonly` `static` **Z7\_QUAD\_MASK**: `17293822569102704640n` = `0xF000000000000000n`
 
-Defined in: [webdggrid.ts:1567](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1567)
+Defined in: [webdggrid.ts:1567](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1567)
 
 **`Internal`**
 
@@ -174,7 +174,7 @@ Defined in: [webdggrid.ts:1567](https://github.com/am2222/webDggrid/blob/7917cb4
 
 > `readonly` `static` **Z7\_QUAD\_OFFSET**: `60n` = `60n`
 
-Defined in: [webdggrid.ts:1566](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1566)
+Defined in: [webdggrid.ts:1566](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1566)
 
 **`Internal`**
 
@@ -184,7 +184,7 @@ Defined in: [webdggrid.ts:1566](https://github.com/am2222/webDggrid/blob/7917cb4
 
 > `readonly` `static` **ZORDER\_BITS\_PER\_DIGIT**: `2n` = `2n`
 
-Defined in: [webdggrid.ts:1578](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1578)
+Defined in: [webdggrid.ts:1578](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1578)
 
 **`Internal`**
 
@@ -194,7 +194,7 @@ Defined in: [webdggrid.ts:1578](https://github.com/am2222/webDggrid/blob/7917cb4
 
 > `readonly` `static` **ZORDER\_DIGIT\_MASK**: `3n` = `3n`
 
-Defined in: [webdggrid.ts:1579](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1579)
+Defined in: [webdggrid.ts:1579](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1579)
 
 **`Internal`**
 
@@ -204,7 +204,7 @@ Defined in: [webdggrid.ts:1579](https://github.com/am2222/webDggrid/blob/7917cb4
 
 > `readonly` `static` **ZORDER\_MAX\_RES**: `30` = `30`
 
-Defined in: [webdggrid.ts:1577](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1577)
+Defined in: [webdggrid.ts:1577](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1577)
 
 **`Internal`**
 
@@ -214,7 +214,7 @@ Defined in: [webdggrid.ts:1577](https://github.com/am2222/webDggrid/blob/7917cb4
 
 > `readonly` `static` **ZORDER\_QUAD\_MASK**: `17293822569102704640n` = `0xF000000000000000n`
 
-Defined in: [webdggrid.ts:1581](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1581)
+Defined in: [webdggrid.ts:1581](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1581)
 
 **`Internal`**
 
@@ -224,7 +224,7 @@ Defined in: [webdggrid.ts:1581](https://github.com/am2222/webDggrid/blob/7917cb4
 
 > `readonly` `static` **ZORDER\_QUAD\_OFFSET**: `60n` = `60n`
 
-Defined in: [webdggrid.ts:1580](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1580)
+Defined in: [webdggrid.ts:1580](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1580)
 
 **`Internal`**
 
@@ -234,7 +234,7 @@ Defined in: [webdggrid.ts:1580](https://github.com/am2222/webDggrid/blob/7917cb4
 
 > **\_main**(): `any`
 
-Defined in: [webdggrid.ts:386](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L386)
+Defined in: [webdggrid.ts:386](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L386)
 
 **`Internal`**
 
@@ -251,7 +251,7 @@ Not intended for production use.
 
 > **cellAreaKM**(`resolution?`): `number`
 
-Defined in: [webdggrid.ts:457](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L457)
+Defined in: [webdggrid.ts:457](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L457)
 
 Returns the average area of a single cell in square kilometres at the
 given resolution.
@@ -284,7 +284,7 @@ Average cell area in km².
 
 > **cellDistKM**(`resolution?`): `number`
 
-Defined in: [webdggrid.ts:500](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L500)
+Defined in: [webdggrid.ts:500](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L500)
 
 Returns the average centre-to-centre distance between neighbouring cells
 in kilometres at the given resolution.
@@ -317,7 +317,7 @@ Average cell spacing in km.
 
 > **geoToGeo**(`coordinates`, `resolution?`): `Position`[]
 
-Defined in: [webdggrid.ts:720](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L720)
+Defined in: [webdggrid.ts:720](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L720)
 
 Snaps an array of geographic coordinates to the centroid of the DGGS
 cell that contains each point.
@@ -367,7 +367,7 @@ Array of `[lng, lat]` cell centroid positions, one per input
 
 > **geoToPlane**(`coordinates`, `resolution?`): `object`[]
 
-Defined in: [webdggrid.ts:1845](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1845)
+Defined in: [webdggrid.ts:1845](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1845)
 
 Converts geographic coordinates to PLANE coordinates.
 
@@ -397,7 +397,7 @@ Array of `{x, y}` plane coordinates
 
 > **geoToProjtri**(`coordinates`, `resolution?`): `object`[]
 
-Defined in: [webdggrid.ts:1866](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1866)
+Defined in: [webdggrid.ts:1866](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1866)
 
 Converts geographic coordinates to PROJTRI coordinates.
 
@@ -427,7 +427,7 @@ Array of `{tnum, x, y}` projection triangle coordinates
 
 > **geoToQ2dd**(`coordinates`, `resolution?`): `object`[]
 
-Defined in: [webdggrid.ts:1891](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1891)
+Defined in: [webdggrid.ts:1891](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1891)
 
 Converts geographic coordinates to Q2DD coordinates.
 
@@ -457,7 +457,7 @@ Array of `{quad, x, y}` quad 2D double coordinates
 
 > **geoToQ2di**(`coordinates`, `resolution?`): `object`[]
 
-Defined in: [webdggrid.ts:1916](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1916)
+Defined in: [webdggrid.ts:1916](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1916)
 
 Converts geographic coordinates to Q2DI coordinates.
 
@@ -487,7 +487,7 @@ Array of `{quad, i, j}` quad 2D integer coordinates
 
 > **geoToSequenceNum**(`coordinates`, `resolution?`): `bigint`[]
 
-Defined in: [webdggrid.ts:601](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L601)
+Defined in: [webdggrid.ts:601](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L601)
 
 Converts an array of geographic coordinates to their corresponding DGGS
 cell sequence numbers (cell IDs) at the given resolution.
@@ -539,7 +539,7 @@ Array of `BigInt` sequence numbers, one per input coordinate,
 
 > **getResolution**(): `number`
 
-Defined in: [webdggrid.ts:362](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L362)
+Defined in: [webdggrid.ts:362](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L362)
 
 Returns the currently active grid resolution.
 
@@ -560,7 +560,7 @@ The current resolution level.
 
 > **gridStatCLS**(`resolution?`): `number`
 
-Defined in: [webdggrid.ts:544](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L544)
+Defined in: [webdggrid.ts:544](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L544)
 
 Returns the characteristic length scale (CLS) of the grid at the given
 resolution — defined as the square root of the average cell area.
@@ -590,11 +590,382 @@ Grid CLS value.
 
 ***
 
+### igeo7Encode()
+
+> **igeo7Encode**(`base`, `digits`): `bigint`
+
+Defined in: [webdggrid.ts:2458](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L2458)
+
+Pack a base cell and exactly 20 digit slots into a 64-bit Z7 index.
+
+Use digit value `7` for every slot beyond the desired resolution.
+Field values are masked internally — no range-check is required.
+
+```ts
+// Reconstruct '0800432' — base=8, resolution=5
+const idx = dggs.igeo7Encode(
+  8, [0,0,4,3,2, 7,7,7,7,7, 7,7,7,7,7, 7,7,7,7,7]
+);
+// idx === dggs.igeo7FromString('0800432')
+```
+
+#### Parameters
+
+##### base
+
+`number`
+
+Base cell (0-11).
+
+##### digits
+
+`number`[]
+
+Exactly 20 digit values (0-7 each).
+
+#### Returns
+
+`bigint`
+
+Packed Z7 index as BigInt.
+
+#### Throws
+
+If `digits.length !== 20`.
+
+***
+
+### igeo7FirstNonZero()
+
+> **igeo7FirstNonZero**(`index`): `number`
+
+Defined in: [webdggrid.ts:2583](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L2583)
+
+Position (1-20) of the first non-zero digit slot in a Z7 index.
+Returns `0` when no non-zero digit exists (centre of the base cell).
+
+#### Parameters
+
+##### index
+
+`bigint`
+
+Packed Z7 index.
+
+#### Returns
+
+`number`
+
+Position of first non-zero digit, or 0.
+
+***
+
+### igeo7FromString()
+
+> **igeo7FromString**(`s`): `bigint`
+
+Defined in: [webdggrid.ts:2418](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L2418)
+
+Parse a Z7 compact string into a packed 64-bit index.
+
+```ts
+const idx = dggs.igeo7FromString('0800432');
+// idx is a BigInt packed index for base=8, digits=[0,0,4,3,2], res=5
+```
+
+#### Parameters
+
+##### s
+
+`string`
+
+Compact Z7 string (2-digit base + digit characters).
+
+#### Returns
+
+`bigint`
+
+Packed index as BigInt (unsigned).
+
+***
+
+### igeo7GetBaseCell()
+
+> **igeo7GetBaseCell**(`index`): `number`
+
+Defined in: [webdggrid.ts:2487](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L2487)
+
+Extract the base cell (0-11) of a packed Z7 index.
+
+#### Parameters
+
+##### index
+
+`bigint`
+
+Packed Z7 index.
+
+#### Returns
+
+`number`
+
+Base cell ID.
+
+***
+
+### igeo7GetDigit()
+
+> **igeo7GetDigit**(`index`, `position`): `number`
+
+Defined in: [webdggrid.ts:2499](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L2499)
+
+Extract the `i`-th digit (1-20) of a packed Z7 index.
+Positions outside `[1, 20]` return `7` (matches DuckDB extension).
+
+#### Parameters
+
+##### index
+
+`bigint`
+
+Packed Z7 index.
+
+##### position
+
+`number`
+
+Digit position, 1-based.
+
+#### Returns
+
+`number`
+
+Digit value (0-7).
+
+***
+
+### igeo7GetResolution()
+
+> **igeo7GetResolution**(`index`): `number`
+
+Defined in: [webdggrid.ts:2477](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L2477)
+
+Extract the resolution (0-20) of a packed Z7 index.
+
+#### Parameters
+
+##### index
+
+`bigint`
+
+Packed Z7 index.
+
+#### Returns
+
+`number`
+
+Resolution level.
+
+***
+
+### igeo7IsValid()
+
+> **igeo7IsValid**(`index`): `boolean`
+
+Defined in: [webdggrid.ts:2593](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L2593)
+
+Whether a packed Z7 index is valid (i.e. not the `UINT64_MAX` sentinel).
+
+#### Parameters
+
+##### index
+
+`bigint`
+
+Packed Z7 index.
+
+#### Returns
+
+`boolean`
+
+`true` if valid, `false` for the invalid sentinel.
+
+***
+
+### igeo7Neighbour()
+
+> **igeo7Neighbour**(`index`, `direction`): `bigint`
+
+Defined in: [webdggrid.ts:2572](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L2572)
+
+Single neighbour of a Z7 cell by GBT direction (1-6).
+
+Returns the invalid sentinel (`UINT64_MAX`) when `direction` is outside
+`[1, 6]` or when the requested neighbour is excluded (pentagons).
+
+#### Parameters
+
+##### index
+
+`bigint`
+
+Packed Z7 index.
+
+##### direction
+
+`number`
+
+Direction number, 1-6.
+
+#### Returns
+
+`bigint`
+
+Neighbour index as BigInt.
+
+***
+
+### igeo7Neighbours()
+
+> **igeo7Neighbours**(`index`): `bigint`[]
+
+Defined in: [webdggrid.ts:2557](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L2557)
+
+Return all 6 neighbour indices of a Z7 cell, in GBT directions 1-6.
+
+Invalid neighbours (e.g. one direction on the 12 pentagons) are the
+sentinel `UINT64_MAX` (`0xFFFFFFFFFFFFFFFFn`). Use [igeo7IsValid](#igeo7isvalid)
+to filter them out.
+
+```ts
+const cell = dggs.igeo7FromString('0800432');
+const ns = dggs.igeo7Neighbours(cell)
+  .filter(n => dggs.igeo7IsValid(n))
+  .map(n => dggs.igeo7ToString(n));
+```
+
+#### Parameters
+
+##### index
+
+`bigint`
+
+Packed Z7 index.
+
+#### Returns
+
+`bigint`[]
+
+Array of exactly 6 BigInt neighbour indices.
+
+***
+
+### igeo7Parent()
+
+> **igeo7Parent**(`index`): `bigint`
+
+Defined in: [webdggrid.ts:2517](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L2517)
+
+Parent of a Z7 cell — one hierarchy level up.
+
+At resolution 0 the cell is its own parent (the result has resolution 0
+and the same base cell).
+
+```ts
+const child = dggs.igeo7FromString('0800432');
+dggs.igeo7ToString(dggs.igeo7Parent(child)); // '080043'
+```
+
+#### Parameters
+
+##### index
+
+`bigint`
+
+Packed Z7 index.
+
+#### Returns
+
+`bigint`
+
+Parent index as BigInt.
+
+***
+
+### igeo7ParentAt()
+
+> **igeo7ParentAt**(`index`, `resolution`): `bigint`
+
+Defined in: [webdggrid.ts:2536](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L2536)
+
+Ancestor of a Z7 cell at a specific resolution.
+
+Keeps digits `1..resolution` and fills the remainder with padding
+(`7`). The argument is clamped to `[0, 20]`.
+
+```ts
+const cell = dggs.igeo7FromString('0800432');
+dggs.igeo7ToString(dggs.igeo7ParentAt(cell, 3)); // '08004'
+```
+
+#### Parameters
+
+##### index
+
+`bigint`
+
+Packed Z7 index.
+
+##### resolution
+
+`number`
+
+Target resolution (0-20).
+
+#### Returns
+
+`bigint`
+
+Ancestor index as BigInt.
+
+***
+
+### igeo7ToString()
+
+> **igeo7ToString**(`index`): `string`
+
+Defined in: [webdggrid.ts:2435](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L2435)
+
+Render a packed Z7 index as its compact string form.
+
+Stops at the first padding digit (value 7), producing a string whose
+length reflects the cell's resolution (`2 + resolution` characters).
+
+```ts
+dggs.igeo7ToString(dggs.igeo7FromString('0800432')); // '0800432'
+```
+
+#### Parameters
+
+##### index
+
+`bigint`
+
+Packed Z7 index.
+
+#### Returns
+
+`string`
+
+Compact Z7 string.
+
+***
+
 ### nCells()
 
 > **nCells**(`resolution?`): `number`
 
-Defined in: [webdggrid.ts:414](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L414)
+Defined in: [webdggrid.ts:414](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L414)
 
 Returns the total number of cells that tile the entire globe at the
 given resolution under the current DGGS configuration.
@@ -636,7 +1007,7 @@ Total number of cells at the given resolution.
 
 > **projtriToGeo**(`coords`, `resolution?`): `Position`[]
 
-Defined in: [webdggrid.ts:2263](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L2263)
+Defined in: [webdggrid.ts:2263](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L2263)
 
 Converts PROJTRI coordinates to geographic coordinates.
 
@@ -666,7 +1037,7 @@ Array of `[lng, lat]` positions
 
 > **projtriToPlane**(`coords`, `resolution?`): `object`[]
 
-Defined in: [webdggrid.ts:2300](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L2300)
+Defined in: [webdggrid.ts:2300](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L2300)
 
 Converts PROJTRI coordinates to PLANE coordinates.
 
@@ -696,7 +1067,7 @@ Array of `{x, y}` plane coordinates
 
 > **projtriToQ2dd**(`coords`, `resolution?`): `object`[]
 
-Defined in: [webdggrid.ts:2322](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L2322)
+Defined in: [webdggrid.ts:2322](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L2322)
 
 Converts PROJTRI coordinates to Q2DD coordinates.
 
@@ -726,7 +1097,7 @@ Array of `{quad, x, y}` quad 2D double coordinates
 
 > **projtriToQ2di**(`coords`, `resolution?`): `object`[]
 
-Defined in: [webdggrid.ts:2348](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L2348)
+Defined in: [webdggrid.ts:2348](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L2348)
 
 Converts PROJTRI coordinates to Q2DI coordinates.
 
@@ -756,7 +1127,7 @@ Array of `{quad, i, j}` quad 2D integer coordinates
 
 > **projtriToSequenceNum**(`coords`, `resolution?`): `bigint`[]
 
-Defined in: [webdggrid.ts:2285](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L2285)
+Defined in: [webdggrid.ts:2285](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L2285)
 
 Converts PROJTRI coordinates to sequence numbers.
 
@@ -786,7 +1157,7 @@ Array of cell IDs
 
 > **q2ddToGeo**(`coords`, `resolution?`): `Position`[]
 
-Defined in: [webdggrid.ts:2148](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L2148)
+Defined in: [webdggrid.ts:2148](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L2148)
 
 Converts Q2DD coordinates to geographic coordinates.
 
@@ -816,7 +1187,7 @@ Array of `[lng, lat]` positions
 
 > **q2ddToPlane**(`coords`, `resolution?`): `object`[]
 
-Defined in: [webdggrid.ts:2185](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L2185)
+Defined in: [webdggrid.ts:2185](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L2185)
 
 Converts Q2DD coordinates to PLANE coordinates.
 
@@ -846,7 +1217,7 @@ Array of `{x, y}` plane coordinates
 
 > **q2ddToProjtri**(`coords`, `resolution?`): `object`[]
 
-Defined in: [webdggrid.ts:2207](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L2207)
+Defined in: [webdggrid.ts:2207](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L2207)
 
 Converts Q2DD coordinates to PROJTRI coordinates.
 
@@ -876,7 +1247,7 @@ Array of `{tnum, x, y}` projection triangle coordinates
 
 > **q2ddToQ2di**(`coords`, `resolution?`): `object`[]
 
-Defined in: [webdggrid.ts:2233](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L2233)
+Defined in: [webdggrid.ts:2233](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L2233)
 
 Converts Q2DD coordinates to Q2DI coordinates.
 
@@ -906,7 +1277,7 @@ Array of `{quad, i, j}` quad 2D integer coordinates
 
 > **q2ddToSequenceNum**(`coords`, `resolution?`): `bigint`[]
 
-Defined in: [webdggrid.ts:2170](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L2170)
+Defined in: [webdggrid.ts:2170](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L2170)
 
 Converts Q2DD coordinates to sequence numbers.
 
@@ -936,7 +1307,7 @@ Array of cell IDs
 
 > **q2diToGeo**(`coords`, `resolution?`): `Position`[]
 
-Defined in: [webdggrid.ts:2033](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L2033)
+Defined in: [webdggrid.ts:2033](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L2033)
 
 Converts Q2DI coordinates to geographic coordinates.
 
@@ -966,7 +1337,7 @@ Array of `[lng, lat]` positions
 
 > **q2diToPlane**(`coords`, `resolution?`): `object`[]
 
-Defined in: [webdggrid.ts:2070](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L2070)
+Defined in: [webdggrid.ts:2070](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L2070)
 
 Converts Q2DI coordinates to PLANE coordinates.
 
@@ -996,7 +1367,7 @@ Array of `{x, y}` plane coordinates
 
 > **q2diToProjtri**(`coords`, `resolution?`): `object`[]
 
-Defined in: [webdggrid.ts:2092](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L2092)
+Defined in: [webdggrid.ts:2092](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L2092)
 
 Converts Q2DI coordinates to PROJTRI coordinates.
 
@@ -1026,7 +1397,7 @@ Array of `{tnum, x, y}` projection triangle coordinates
 
 > **q2diToQ2dd**(`coords`, `resolution?`): `object`[]
 
-Defined in: [webdggrid.ts:2118](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L2118)
+Defined in: [webdggrid.ts:2118](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L2118)
 
 Converts Q2DI coordinates to Q2DD coordinates.
 
@@ -1056,7 +1427,7 @@ Array of `{quad, x, y}` quad 2D double coordinates
 
 > **q2diToSequenceNum**(`coords`, `resolution?`): `bigint`[]
 
-Defined in: [webdggrid.ts:2055](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L2055)
+Defined in: [webdggrid.ts:2055](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L2055)
 
 Converts Q2DI coordinates to sequence numbers.
 
@@ -1086,7 +1457,7 @@ Array of cell IDs
 
 > **sequenceNumAllParents**(`sequenceNum`, `resolution?`): `bigint`[][]
 
-Defined in: [webdggrid.ts:1082](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1082)
+Defined in: [webdggrid.ts:1082](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1082)
 
 Returns **all** parent cells that touch each input cell at the coarser
 resolution (resolution - 1).
@@ -1139,7 +1510,7 @@ If `resolution` is 0 or negative, or if an invalid cell ID is
 
 > **sequenceNumChildren**(`sequenceNum`, `resolution?`): `bigint`[][]
 
-Defined in: [webdggrid.ts:1142](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1142)
+Defined in: [webdggrid.ts:1142](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1142)
 
 Returns all child cells at the next finer resolution (resolution + 1)
 for each input cell.
@@ -1195,7 +1566,7 @@ If an invalid cell ID is provided or if the maximum resolution
 
 > **sequenceNumNeighbors**(`sequenceNum`, `resolution?`): `bigint`[][]
 
-Defined in: [webdggrid.ts:935](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L935)
+Defined in: [webdggrid.ts:935](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L935)
 
 Returns all neighboring cells (sharing an edge) for each input cell.
 
@@ -1248,7 +1619,7 @@ If Triangle topology is used or if an invalid cell ID is provided.
 
 > **sequenceNumParent**(`sequenceNum`, `resolution?`): `bigint`[]
 
-Defined in: [webdggrid.ts:1014](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1014)
+Defined in: [webdggrid.ts:1014](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1014)
 
 Returns the parent cell at the next coarser resolution (resolution - 1)
 for each input cell.
@@ -1299,7 +1670,7 @@ If resolution is 0 or if an invalid cell ID is provided.
 
 > **sequenceNumToGeo**(`sequenceNum`, `resolution?`): `Position`[]
 
-Defined in: [webdggrid.ts:655](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L655)
+Defined in: [webdggrid.ts:655](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L655)
 
 Converts an array of DGGS cell sequence numbers to the geographic
 coordinates of their centroids.
@@ -1340,7 +1711,7 @@ Array of `[lng, lat]` centroid positions, one per input ID, in
 
 > **sequenceNumToGrid**(`sequenceNum`, `resolution?`): `Position`[][]
 
-Defined in: [webdggrid.ts:785](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L785)
+Defined in: [webdggrid.ts:785](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L785)
 
 Returns the polygon boundary vertices for each cell in `sequenceNum`.
 
@@ -1389,7 +1760,7 @@ If the WASM module encounters an invalid cell ID.
 
 > **sequenceNumToGridFeatureCollection**(`sequenceNum`, `resolution?`): `FeatureCollection`\<`Polygon`, `object` & `object`\>
 
-Defined in: [webdggrid.ts:880](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L880)
+Defined in: [webdggrid.ts:880](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L880)
 
 Converts an array of DGGS cell IDs into a GeoJSON `FeatureCollection`
 where each `Feature` is a `Polygon` representing the cell boundary.
@@ -1445,7 +1816,7 @@ A GeoJSON `FeatureCollection` of `Polygon` features, one per
 
 > **sequenceNumToPlane**(`sequenceNum`, `resolution?`): `object`[]
 
-Defined in: [webdggrid.ts:1945](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1945)
+Defined in: [webdggrid.ts:1945](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1945)
 
 Converts sequence numbers to PLANE coordinates.
 
@@ -1475,7 +1846,7 @@ Array of `{x, y}` plane coordinates
 
 > **sequenceNumToProjtri**(`sequenceNum`, `resolution?`): `object`[]
 
-Defined in: [webdggrid.ts:1963](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1963)
+Defined in: [webdggrid.ts:1963](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1963)
 
 Converts sequence numbers to PROJTRI coordinates.
 
@@ -1505,7 +1876,7 @@ Array of `{tnum, x, y}` projection triangle coordinates
 
 > **sequenceNumToQ2dd**(`sequenceNum`, `resolution?`): `object`[]
 
-Defined in: [webdggrid.ts:1985](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1985)
+Defined in: [webdggrid.ts:1985](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1985)
 
 Converts sequence numbers to Q2DD coordinates.
 
@@ -1535,7 +1906,7 @@ Array of `{quad, x, y}` quad 2D double coordinates
 
 > **sequenceNumToQ2di**(`sequenceNum`, `resolution?`): `object`[]
 
-Defined in: [webdggrid.ts:2007](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L2007)
+Defined in: [webdggrid.ts:2007](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L2007)
 
 Converts sequence numbers to Q2DI coordinates.
 
@@ -1565,7 +1936,7 @@ Array of `{quad, i, j}` quad 2D integer coordinates
 
 > **sequenceNumToVertex2DD**(`sequenceNum`, `resolution?`): [`Vertex2DDCoordinate`](../interfaces/Vertex2DDCoordinate.md)
 
-Defined in: [webdggrid.ts:1214](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1214)
+Defined in: [webdggrid.ts:1214](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1214)
 
 Convert a SEQNUM cell ID to VERTEX2DD (icosahedral vertex) coordinates.
 
@@ -1605,7 +1976,7 @@ An object with `{keep, vertNum, triNum, x, y}` representing
 
 > **sequenceNumToZ3**(`sequenceNum`, `resolution?`): `bigint`
 
-Defined in: [webdggrid.ts:1386](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1386)
+Defined in: [webdggrid.ts:1386](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1386)
 
 Convert a SEQNUM cell ID to Z3 (base-3 Central Place Indexing) coordinate.
 
@@ -1651,7 +2022,7 @@ If used with an incompatible aperture (not 3) or topology.
 
 > **sequenceNumToZ7**(`sequenceNum`, `resolution?`): `bigint`
 
-Defined in: [webdggrid.ts:1481](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1481)
+Defined in: [webdggrid.ts:1481](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1481)
 
 Convert a SEQNUM cell ID to Z7 (base-7 Central Place Indexing) coordinate.
 
@@ -1698,7 +2069,7 @@ If used with an incompatible aperture (not 7) or topology.
 
 > **sequenceNumToZOrder**(`sequenceNum`, `resolution?`): `bigint`
 
-Defined in: [webdggrid.ts:1291](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1291)
+Defined in: [webdggrid.ts:1291](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1291)
 
 Convert a SEQNUM cell ID to ZORDER (Z-order curve) coordinate.
 
@@ -1745,7 +2116,7 @@ If used with an incompatible aperture (7) or topology.
 
 > **setDggs**(`dggs?`, `resolution?`): `void`
 
-Defined in: [webdggrid.ts:347](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L347)
+Defined in: [webdggrid.ts:347](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L347)
 
 Sets both the DGGS configuration and the resolution in one call.
 
@@ -1786,7 +2157,7 @@ The new resolution level. Defaults to `1`.
 
 > **setResolution**(`resolution`): `void`
 
-Defined in: [webdggrid.ts:377](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L377)
+Defined in: [webdggrid.ts:377](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L377)
 
 Sets the grid resolution used by default in all conversion and
 statistics methods.
@@ -1814,7 +2185,7 @@ The new resolution level. Must be a positive integer.
 
 > **version**(): `string`
 
-Defined in: [webdggrid.ts:324](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L324)
+Defined in: [webdggrid.ts:324](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L324)
 
 Returns the version string of the underlying DGGRID C++ library.
 
@@ -1834,7 +2205,7 @@ The DGGRID C++ library version string.
 
 > **vertex2DDToSequenceNum**(`keep`, `vertNum`, `triNum`, `x`, `y`, `resolution?`): `bigint`
 
-Defined in: [webdggrid.ts:1247](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1247)
+Defined in: [webdggrid.ts:1247](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1247)
 
 Convert VERTEX2DD (icosahedral vertex) coordinates to a SEQNUM cell ID.
 
@@ -1894,7 +2265,7 @@ The sequence number (BigInt) of the cell containing this coordinate.
 
 > **z3ExtractDigits**(`z3Value`, `resolution`): `object`
 
-Defined in: [webdggrid.ts:1720](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1720)
+Defined in: [webdggrid.ts:1720](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1720)
 
 Extract all digits from a Z3 index up to a given resolution.
 
@@ -1937,7 +2308,7 @@ Object with `quad` (number) and `digits` (number array).
 
 > **z3GetDigit**(`z3Value`, `res`): `number`
 
-Defined in: [webdggrid.ts:1686](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1686)
+Defined in: [webdggrid.ts:1686](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1686)
 
 Get the digit at a specific resolution level from a Z3 index.
 
@@ -1974,7 +2345,7 @@ The digit value (0–3).
 
 > **z3GetQuad**(`z3Value`): `number`
 
-Defined in: [webdggrid.ts:1668](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1668)
+Defined in: [webdggrid.ts:1668](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1668)
 
 Get the quad (icosahedron face) number from a Z3 index.
 
@@ -2002,7 +2373,7 @@ The quad number (0–11).
 
 > **z3SetDigit**(`z3Value`, `res`, `digit`): `bigint`
 
-Defined in: [webdggrid.ts:1703](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1703)
+Defined in: [webdggrid.ts:1703](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1703)
 
 Set the digit at a specific resolution level in a Z3 index.
 
@@ -2042,7 +2413,7 @@ A new Z3 value with the digit replaced.
 
 > **z3ToSequenceNum**(`z3Value`, `resolution?`): `bigint`
 
-Defined in: [webdggrid.ts:1430](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1430)
+Defined in: [webdggrid.ts:1430](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1430)
 
 Convert a Z3 (base-3 Central Place Indexing) coordinate to a SEQNUM cell ID.
 
@@ -2082,7 +2453,7 @@ If used with an incompatible aperture (not 3) or topology.
 
 > **z7ExtractDigits**(`z7Value`, `resolution`): `object`
 
-Defined in: [webdggrid.ts:1649](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1649)
+Defined in: [webdggrid.ts:1649](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1649)
 
 Extract all digits from a Z7 index up to a given resolution.
 
@@ -2125,7 +2496,7 @@ Object with `quad` (number) and `digits` (number array).
 
 > **z7GetDigit**(`z7Value`, `res`): `number`
 
-Defined in: [webdggrid.ts:1613](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1613)
+Defined in: [webdggrid.ts:1613](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1613)
 
 Get the digit at a specific resolution level from a Z7 index.
 
@@ -2162,7 +2533,7 @@ The digit value (0–7).
 
 > **z7GetQuad**(`z7Value`): `number`
 
-Defined in: [webdggrid.ts:1595](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1595)
+Defined in: [webdggrid.ts:1595](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1595)
 
 Get the quad (icosahedron face) number from a Z7 index.
 
@@ -2192,7 +2563,7 @@ The quad number (0–11).
 
 > **z7SetDigit**(`z7Value`, `res`, `digit`): `bigint`
 
-Defined in: [webdggrid.ts:1632](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1632)
+Defined in: [webdggrid.ts:1632](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1632)
 
 Set the digit at a specific resolution level in a Z7 index.
 
@@ -2234,7 +2605,7 @@ A new Z7 value with the digit replaced.
 
 > **z7ToSequenceNum**(`z7Value`, `resolution?`): `bigint`
 
-Defined in: [webdggrid.ts:1525](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1525)
+Defined in: [webdggrid.ts:1525](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1525)
 
 Convert a Z7 (base-7 Central Place Indexing) coordinate to a SEQNUM cell ID.
 
@@ -2274,7 +2645,7 @@ If used with an incompatible aperture (not 7) or topology.
 
 > **zOrderExtractDigits**(`zorderValue`, `resolution`): `object`
 
-Defined in: [webdggrid.ts:1790](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1790)
+Defined in: [webdggrid.ts:1790](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1790)
 
 Extract all digits from a ZORDER index up to a given resolution.
 
@@ -2317,7 +2688,7 @@ Object with `quad` (number) and `digits` (number array).
 
 > **zOrderGetDigit**(`zorderValue`, `res`): `number`
 
-Defined in: [webdggrid.ts:1756](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1756)
+Defined in: [webdggrid.ts:1756](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1756)
 
 Get the digit at a specific resolution level from a ZORDER index.
 
@@ -2353,7 +2724,7 @@ The digit value (0–3).
 
 > **zOrderGetQuad**(`zorderValue`): `number`
 
-Defined in: [webdggrid.ts:1739](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1739)
+Defined in: [webdggrid.ts:1739](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1739)
 
 Get the quad (icosahedron face) number from a ZORDER index.
 
@@ -2381,7 +2752,7 @@ The quad number (0–11).
 
 > **zOrderSetDigit**(`zorderValue`, `res`, `digit`): `bigint`
 
-Defined in: [webdggrid.ts:1773](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1773)
+Defined in: [webdggrid.ts:1773](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1773)
 
 Set the digit at a specific resolution level in a ZORDER index.
 
@@ -2421,7 +2792,7 @@ A new ZORDER value with the digit replaced.
 
 > **zOrderToSequenceNum**(`zorderValue`, `resolution?`): `bigint`
 
-Defined in: [webdggrid.ts:1336](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L1336)
+Defined in: [webdggrid.ts:1336](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L1336)
 
 Convert a ZORDER (Z-order curve) coordinate to a SEQNUM cell ID.
 
@@ -2461,7 +2832,7 @@ If used with an incompatible aperture (7) or topology.
 
 > `static` **load**(): `Promise`\<*typeof* `Webdggrid`\>
 
-Defined in: [webdggrid.ts:298](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L298)
+Defined in: [webdggrid.ts:298](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L298)
 
 Compiles and instantiates the DGGRID WebAssembly module.
 
@@ -2491,7 +2862,7 @@ A promise that resolves to a fully initialised `Webdggrid` instance.
 
 > `static` **unload**(): `void`
 
-Defined in: [webdggrid.ts:311](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L311)
+Defined in: [webdggrid.ts:311](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L311)
 
 Releases the compiled WASM instance and frees its memory.
 

--- a/docs/api/enumerations/Projection.md
+++ b/docs/api/enumerations/Projection.md
@@ -2,7 +2,7 @@
 
 # Enumeration: Projection
 
-Defined in: [webdggrid.ts:49](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L49)
+Defined in: [webdggrid.ts:49](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L49)
 
 The map projection used to place the polyhedron faces onto the sphere.
 
@@ -27,7 +27,7 @@ dggs.setDggs({ projection: Projection.ISEA, ... }, 4);
 
 > **FULLER**: `"FULLER"`
 
-Defined in: [webdggrid.ts:53](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L53)
+Defined in: [webdggrid.ts:53](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L53)
 
 Fuller/Dymaxion projection — shape-preserving cells.
 
@@ -37,6 +37,6 @@ Fuller/Dymaxion projection — shape-preserving cells.
 
 > **ISEA**: `"ISEA"`
 
-Defined in: [webdggrid.ts:51](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L51)
+Defined in: [webdggrid.ts:51](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L51)
 
 Icosahedral Snyder Equal Area projection — equal-area cells.

--- a/docs/api/enumerations/Topology.md
+++ b/docs/api/enumerations/Topology.md
@@ -2,7 +2,7 @@
 
 # Enumeration: Topology
 
-Defined in: [webdggrid.ts:22](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L22)
+Defined in: [webdggrid.ts:22](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L22)
 
 The shape of each cell in the Discrete Global Grid System.
 
@@ -26,7 +26,7 @@ dggs.setDggs({ topology: Topology.HEXAGON, ... }, 4);
 
 > **DIAMOND**: `"DIAMOND"`
 
-Defined in: [webdggrid.ts:28](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L28)
+Defined in: [webdggrid.ts:28](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L28)
 
 Four-sided diamond cells (squares rotated 45°).
 
@@ -36,7 +36,7 @@ Four-sided diamond cells (squares rotated 45°).
 
 > **HEXAGON**: `"HEXAGON"`
 
-Defined in: [webdggrid.ts:24](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L24)
+Defined in: [webdggrid.ts:24](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L24)
 
 Six-sided cells — the default and most widely used topology.
 
@@ -46,6 +46,6 @@ Six-sided cells — the default and most widely used topology.
 
 > **TRIANGLE**: `"TRIANGLE"`
 
-Defined in: [webdggrid.ts:26](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L26)
+Defined in: [webdggrid.ts:26](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L26)
 
 Three-sided cells.

--- a/docs/api/functions/unwrapAntimeridianRing.md
+++ b/docs/api/functions/unwrapAntimeridianRing.md
@@ -4,7 +4,7 @@
 
 > **unwrapAntimeridianRing**(`ring`): `Position`[]
 
-Defined in: [webdggrid.ts:195](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L195)
+Defined in: [webdggrid.ts:195](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L195)
 
 Rewraps a polygon ring that crosses the antimeridian so that all longitudes
 are in a contiguous range (some may exceed 180°).  This is the format

--- a/docs/api/interfaces/Coordinate.md
+++ b/docs/api/interfaces/Coordinate.md
@@ -2,7 +2,7 @@
 
 # Interface: Coordinate
 
-Defined in: [webdggrid.ts:65](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L65)
+Defined in: [webdggrid.ts:65](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L65)
 
 A simple geographic coordinate expressed as latitude and longitude in
 decimal degrees (WGS-84).
@@ -19,7 +19,7 @@ const coord: Coordinate = { lat: 51.5, lng: -0.1 };
 
 > **lat**: `number`
 
-Defined in: [webdggrid.ts:67](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L67)
+Defined in: [webdggrid.ts:67](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L67)
 
 Latitude in decimal degrees. Range: −90 to 90.
 
@@ -29,6 +29,6 @@ Latitude in decimal degrees. Range: −90 to 90.
 
 > **lng**: `number`
 
-Defined in: [webdggrid.ts:69](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L69)
+Defined in: [webdggrid.ts:69](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L69)
 
 Longitude in decimal degrees. Range: −180 to 180.

--- a/docs/api/interfaces/IDGGSProps.md
+++ b/docs/api/interfaces/IDGGSProps.md
@@ -2,7 +2,7 @@
 
 # Interface: IDGGSProps
 
-Defined in: [webdggrid.ts:136](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L136)
+Defined in: [webdggrid.ts:136](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L136)
 
 Full configuration of a Discrete Global Grid System.
 
@@ -32,7 +32,7 @@ dggs.setDggs(myDggs, 5);
 
 > `optional` **aperture?**: `7` \| `3` \| `4` \| `5`
 
-Defined in: [webdggrid.ts:162](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L162)
+Defined in: [webdggrid.ts:162](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L162)
 
 Subdivision aperture — the number of child cells each parent cell is
 divided into when moving to the next finer resolution.
@@ -52,7 +52,7 @@ Ignored if `apertureSequence` is specified.
 
 > `optional` **apertureSequence?**: `string`
 
-Defined in: [webdggrid.ts:181](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L181)
+Defined in: [webdggrid.ts:181](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L181)
 
 Mixed aperture sequence (e.g., `"434747"`).
 
@@ -78,7 +78,7 @@ apertureSequence: "434747"
 
 > **azimuth**: `number`
 
-Defined in: [webdggrid.ts:148](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L148)
+Defined in: [webdggrid.ts:148](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L148)
 
 Azimuth of the icosahedron pole in decimal degrees.
 Rotates the grid around the pole axis. Defaults to `0`.
@@ -89,7 +89,7 @@ Rotates the grid around the pole axis. Defaults to `0`.
 
 > **poleCoordinates**: [`Coordinate`](Coordinate.md)
 
-Defined in: [webdggrid.ts:143](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L143)
+Defined in: [webdggrid.ts:143](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L143)
 
 Geographic location of the icosahedron pole used to orient the grid.
 Changing this rotates the entire grid on the globe, which can be used
@@ -102,7 +102,7 @@ Defaults to `{ lat: 0, lng: 0 }`.
 
 > **projection**: [`Projection`](../enumerations/Projection.md)
 
-Defined in: [webdggrid.ts:185](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L185)
+Defined in: [webdggrid.ts:185](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L185)
 
 Projection used to map the polyhedron faces onto the sphere. See [Projection](../enumerations/Projection.md).
 
@@ -112,6 +112,6 @@ Projection used to map the polyhedron faces onto the sphere. See [Projection](..
 
 > **topology**: [`Topology`](../enumerations/Topology.md)
 
-Defined in: [webdggrid.ts:183](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L183)
+Defined in: [webdggrid.ts:183](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L183)
 
 Shape of each cell. See [Topology](../enumerations/Topology.md).

--- a/docs/api/interfaces/Vertex2DDCoordinate.md
+++ b/docs/api/interfaces/Vertex2DDCoordinate.md
@@ -2,7 +2,7 @@
 
 # Interface: Vertex2DDCoordinate
 
-Defined in: [webdggrid.ts:78](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L78)
+Defined in: [webdggrid.ts:78](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L78)
 
 VERTEX2DD coordinate representation.
 
@@ -15,7 +15,7 @@ faces in DGGRID's coordinate system.
 
 > **keep**: `boolean`
 
-Defined in: [webdggrid.ts:80](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L80)
+Defined in: [webdggrid.ts:80](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L80)
 
 Whether to keep this vertex.
 
@@ -25,7 +25,7 @@ Whether to keep this vertex.
 
 > **triNum**: `number`
 
-Defined in: [webdggrid.ts:84](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L84)
+Defined in: [webdggrid.ts:84](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L84)
 
 Triangle number on the icosahedron.
 
@@ -35,7 +35,7 @@ Triangle number on the icosahedron.
 
 > **vertNum**: `number`
 
-Defined in: [webdggrid.ts:82](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L82)
+Defined in: [webdggrid.ts:82](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L82)
 
 Vertex number (0-11 for icosahedron).
 
@@ -45,7 +45,7 @@ Vertex number (0-11 for icosahedron).
 
 > **x**: `number`
 
-Defined in: [webdggrid.ts:86](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L86)
+Defined in: [webdggrid.ts:86](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L86)
 
 X coordinate within the triangle.
 
@@ -55,6 +55,6 @@ X coordinate within the triangle.
 
 > **y**: `number`
 
-Defined in: [webdggrid.ts:88](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L88)
+Defined in: [webdggrid.ts:88](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L88)
 
 Y coordinate within the triangle.

--- a/docs/api/type-aliases/DGGSGeoJsonProperty.md
+++ b/docs/api/type-aliases/DGGSGeoJsonProperty.md
@@ -4,7 +4,7 @@
 
 > **DGGSGeoJsonProperty** = `GeoJsonProperties` & `object`
 
-Defined in: [webdggrid.ts:102](https://github.com/am2222/webDggrid/blob/7917cb44f49dfd54c006cb0b682993cf9f954743/src-ts/webdggrid.ts#L102)
+Defined in: [webdggrid.ts:102](https://github.com/am2222/webDggrid/blob/6a20c6a662c56fec4ef89c53e60cb9df7b144cb1/src-ts/webdggrid.ts#L102)
 
 GeoJSON `properties` object attached to every cell feature returned by
 [Webdggrid.sequenceNumToGridFeatureCollection](../classes/Webdggrid.md#sequencenumtogridfeaturecollection).

--- a/docs/hierarchical-addresses.md
+++ b/docs/hierarchical-addresses.md
@@ -13,6 +13,11 @@ In addition to the standard SEQNUM (sequence number) addressing, WebDGGRID provi
 | **Z3** | Base-3 Central Place Indexing | Aperture 3 hexagons only | Aperture 3 hierarchical indexing |
 | **Z7** | Base-7 Central Place Indexing | Aperture 7 hexagons only | Aperture 7 hierarchical indexing |
 
+> **See also:** [IGEO7 / Z7 Index](./igeo7.md) — a stateless, standalone API
+> for bit-level manipulation of packed Z7 indices (parent, neighbours,
+> encode/decode) wire-compatible with the
+> [igeo7 DuckDB extension](https://github.com/allixender/igeo7_duckdb).
+
 ## Interactive Demo
 
 Select an address type to see how cell identifiers change across different indexing systems. Click any cell to inspect all its address representations and verify round-trip conversions.

--- a/docs/igeo7.md
+++ b/docs/igeo7.md
@@ -1,0 +1,167 @@
+# IGEO7 / Z7 Hexagonal Hierarchical Index
+
+WebDGGRID embeds the upstream [Z7 C++ core library](https://github.com/allixender/igeo7_duckdb)
+and surfaces every `igeo7_*` scalar function from the DuckDB extension as a
+JavaScript method on `Webdggrid`.
+
+The IGEO7 index is a **64-bit packed integer** that uniquely identifies a cell
+in a hexagonal aperture-7 discrete global grid up to resolution 20. All
+operations are pure bit-level manipulations — they run in nanoseconds and do
+**not** require a DGGS configuration. You can call them immediately after
+`Webdggrid.load()`.
+
+## Index format
+
+```
+bits [63:60]  base cell  (4 bits, values 0-11)
+bits [59:57]  digit  1   (3 bits, values 0-6; 7 = padding / unused slot)
+bits [56:54]  digit  2
+...
+bits  [2: 0]  digit 20
+```
+
+The **compact string** form (`igeo7ToString`) is a 2-digit zero-padded base
+cell followed by digit characters, stopping before the first padding digit
+(`7`):
+
+```
+0800432  →  base 08, digits 0,0,4,3,2, resolution 5
+```
+
+Invalid or excluded cells are represented by the sentinel
+`0xFFFFFFFFFFFFFFFFn` (`UINT64_MAX`). Use `igeo7IsValid` to filter them.
+
+## Interactive demo
+
+Type a Z7 string to see its decomposition, parent chain, and 6 neighbours.
+Click `→ inspect` on any related cell to drill into it.
+
+<ClientOnly>
+  <Igeo7Demo />
+</ClientOnly>
+
+## API
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `igeo7FromString` | `(s: string) → bigint` | Parse compact Z7 string to packed index |
+| `igeo7ToString` | `(index: bigint) → string` | Render packed index as compact string |
+| `igeo7Encode` | `(base: number, digits: number[20]) → bigint` | Pack base cell + 20 digit slots |
+| `igeo7GetResolution` | `(index: bigint) → number` | Resolution (0-20) of the index |
+| `igeo7GetBaseCell` | `(index: bigint) → number` | Base cell ID (0-11) |
+| `igeo7GetDigit` | `(index: bigint, position: number) → number` | Extract the i-th digit (1-20) |
+| `igeo7Parent` | `(index: bigint) → bigint` | Parent index (one level up) |
+| `igeo7ParentAt` | `(index: bigint, resolution: number) → bigint` | Ancestor at a specific resolution |
+| `igeo7Neighbours` | `(index: bigint) → bigint[6]` | All 6 neighbours (pentagon-excluded = `UINT64_MAX`) |
+| `igeo7Neighbour` | `(index: bigint, direction: number) → bigint` | Single neighbour by direction (1-6) |
+| `igeo7FirstNonZero` | `(index: bigint) → number` | Position of first non-zero digit slot |
+| `igeo7IsValid` | `(index: bigint) → boolean` | `false` when index equals the invalid sentinel |
+
+## Examples
+
+### Round-trip between string and packed index
+
+```typescript
+import { Webdggrid } from 'webdggrid';
+
+const dggs = await Webdggrid.load();
+
+const idx = dggs.igeo7FromString('0800432');
+// 9241389823593963519n
+
+dggs.igeo7ToString(idx);
+// '0800432'
+
+dggs.igeo7GetResolution(idx); // 5
+dggs.igeo7GetBaseCell(idx);   // 8
+```
+
+### Encode a cell from its components
+
+`igeo7Encode` is the inverse of `igeo7GetBaseCell` + `igeo7GetDigit`. Use `7`
+for every padding slot beyond the target resolution.
+
+```typescript
+// Reconstruct '0800432' — base=8, resolution=5
+const cell = dggs.igeo7Encode(8, [
+    0, 0, 4, 3, 2,
+    7, 7, 7, 7, 7,
+    7, 7, 7, 7, 7,
+    7, 7, 7, 7, 7,
+]);
+
+cell === dggs.igeo7FromString('0800432'); // true
+```
+
+### Extract individual digits
+
+```typescript
+const idx = dggs.igeo7FromString('0800432');
+
+dggs.igeo7GetDigit(idx, 1); // 0
+dggs.igeo7GetDigit(idx, 2); // 0
+dggs.igeo7GetDigit(idx, 3); // 4
+dggs.igeo7GetDigit(idx, 4); // 3
+dggs.igeo7GetDigit(idx, 5); // 2
+dggs.igeo7GetDigit(idx, 6); // 7  (padding — beyond resolution)
+```
+
+### Walk up the hierarchy
+
+```typescript
+let cell = dggs.igeo7FromString('0800432');
+
+while (dggs.igeo7GetResolution(cell) > 0) {
+    console.log(dggs.igeo7ToString(cell));
+    cell = dggs.igeo7Parent(cell);
+}
+// 0800432, 080043, 08004, 0800, 080, 08
+```
+
+Or jump directly to a given ancestor resolution:
+
+```typescript
+const cell = dggs.igeo7FromString('0800432');
+dggs.igeo7ToString(dggs.igeo7ParentAt(cell, 3)); // '08004'
+```
+
+### Neighbours
+
+```typescript
+const cell = dggs.igeo7FromString('0800432');
+
+// All 6 neighbours (GBT directions 1-6)
+const ns = dggs.igeo7Neighbours(cell)
+    .filter(n => dggs.igeo7IsValid(n))
+    .map(n => dggs.igeo7ToString(n));
+
+// Single neighbour by direction
+dggs.igeo7ToString(dggs.igeo7Neighbour(cell, 1));
+```
+
+Pentagons (the 12 special base cells at resolution 0) have one excluded
+direction, returned as the invalid sentinel:
+
+```typescript
+const pent = dggs.igeo7FromString('0800'); // a pentagon at res 2
+const ns = dggs.igeo7Neighbours(pent);
+ns.filter(n => !dggs.igeo7IsValid(n)).length; // exactly 1
+```
+
+## Relationship to DGGRID's built-in Z7
+
+DGGRID ships its own Z7 implementation accessible via `sequenceNumToZ7` /
+`z7ToSequenceNum` — those methods convert between DGGRID sequence numbers and
+Z7 indices for the **currently configured** DGGS at a specific resolution.
+
+The `igeo7*` methods on this page are a **stateless, standalone** surface on
+top of the upstream Z7 core library. They are useful when you have Z7 indices
+from another system (e.g. a DuckDB column produced by the `igeo7_*` SQL
+extension) and want to inspect or manipulate them without first setting a
+DGGS configuration.
+
+## Source
+
+- Upstream: [allixender/igeo7_duckdb](https://github.com/allixender/igeo7_duckdb)
+- Vendored at: `submodules/igeo7_duckdb/src/z7/`
+- WASM bindings: `src-cpp/igeo7_bindings.cpp`

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,4 +25,6 @@ features:
     details: Configure grids with mixed aperture sequences (e.g., "434747") for flexible grid refinement strategies and custom analysis needs.
   - title: GeoJSON Ready
     details: Convert coordinates to DGGS cell IDs and back, or export entire grid regions directly as GeoJSON FeatureCollections for use with mapping libraries.
+  - title: IGEO7 / Z7 Index
+    details: Stateless bit-level operations on packed 64-bit Z7 indices — parent, neighbours, encode/decode — wire-compatible with the <a href="https://github.com/allixender/igeo7_duckdb">igeo7 DuckDB extension</a>. <a href="/webDggrid/igeo7">Learn more →</a>
 ---

--- a/src-cpp/igeo7_bindings.cpp
+++ b/src-cpp/igeo7_bindings.cpp
@@ -1,0 +1,195 @@
+// ---------------------------------------------------------------------------
+// Emscripten bindings for the IGEO7/Z7 hexagonal hierarchical index.
+//
+// Wraps the upstream Z7 C++ core library (from allixender/igeo7_duckdb) so
+// every `igeo7_*` scalar function exposed by the DuckDB extension is callable
+// from JavaScript. These are stateless bit-level operations on a packed
+// uint64_t — no DGGS configuration is required.
+//
+// Bit layout (MSB → LSB):
+//   [63:60]  base cell  (4 bits, 0-11)
+//   [59:57]  digit  1   (3 bits, 0-6; 7 = padding/unused slot)
+//   [56:54]  digit  2
+//   ...
+//   [ 2: 0]  digit 20   (3 bits)
+// ---------------------------------------------------------------------------
+
+#include <emscripten/bind.h>
+
+#include "z7/library.h"
+
+#include <array>
+#include <cstdint>
+#include <limits>
+#include <string>
+
+using namespace emscripten;
+
+// Shared, stateless Z7 configuration.
+static const Z7::Z7Configuration DEFAULT_CONFIG{};
+
+// ---------------------------------------------------------------------------
+// igeo7_get_resolution(UBIGINT) → INTEGER
+// ---------------------------------------------------------------------------
+static int32_t igeo7_get_resolution(uint64_t raw) {
+    Z7::Z7Index idx(raw);
+    return idx.resolution();
+}
+
+// ---------------------------------------------------------------------------
+// igeo7_get_base_cell(UBIGINT) → UTINYINT
+// ---------------------------------------------------------------------------
+static int igeo7_get_base_cell(uint64_t raw) {
+    Z7::Z7Index idx(raw);
+    return static_cast<int>(idx.hierarchy.base);
+}
+
+// ---------------------------------------------------------------------------
+// igeo7_get_digit(UBIGINT, INTEGER) → UTINYINT
+// Returns 7 for out-of-range positions (matches DuckDB extension).
+// ---------------------------------------------------------------------------
+static int igeo7_get_digit(uint64_t raw, int32_t pos) {
+    if (pos < 1 || pos > 20) return 7;
+    Z7::Z7Index idx(raw);
+    return static_cast<int>(*idx[static_cast<uint64_t>(pos)]);
+}
+
+// ---------------------------------------------------------------------------
+// igeo7_parent(UBIGINT) → UBIGINT   — go one level up
+// ---------------------------------------------------------------------------
+static uint64_t igeo7_parent(uint64_t raw) {
+    Z7::Z7Index idx(raw);
+    int res = idx.resolution();
+    int target = res > 0 ? res - 1 : 0;
+    Z7::Z7Index parent;
+    parent.hierarchy.base = idx.hierarchy.base;
+    for (int i = 1; i <= target; i++) {
+        parent[i] = *idx[i];
+    }
+    for (int i = target + 1; i <= 20; i++) {
+        parent[i] = 7;
+    }
+    return parent.index;
+}
+
+// ---------------------------------------------------------------------------
+// igeo7_parent_at(UBIGINT, INTEGER) → UBIGINT   — ancestor at a given resolution
+// Clamps `resolution` to [0, 20].
+// ---------------------------------------------------------------------------
+static uint64_t igeo7_parent_at(uint64_t raw, int32_t resolution) {
+    if (resolution < 0) resolution = 0;
+    if (resolution > 20) resolution = 20;
+    Z7::Z7Index idx(raw);
+    Z7::Z7Index parent;
+    parent.hierarchy.base = idx.hierarchy.base;
+    for (int i = 1; i <= resolution; i++) {
+        parent[i] = *idx[i];
+    }
+    for (int i = resolution + 1; i <= 20; i++) {
+        parent[i] = 7;
+    }
+    return parent.index;
+}
+
+// ---------------------------------------------------------------------------
+// igeo7_to_string(UBIGINT) → VARCHAR      — compact form (stops before first 7)
+// ---------------------------------------------------------------------------
+static std::string igeo7_to_string(uint64_t raw) {
+    Z7::Z7Index idx(raw);
+    return idx.str();
+}
+
+// ---------------------------------------------------------------------------
+// igeo7_from_string(VARCHAR) → UBIGINT
+// ---------------------------------------------------------------------------
+static uint64_t igeo7_from_string(const std::string& s) {
+    Z7::Z7Index idx(s);
+    return idx.index;
+}
+
+// ---------------------------------------------------------------------------
+// igeo7_get_neighbours(UBIGINT) → UBIGINT[6]
+// Invalid neighbours (e.g., pentagon exclusion) are UINT64_MAX.
+// ---------------------------------------------------------------------------
+static val igeo7_get_neighbours(uint64_t raw) {
+    Z7::Z7Index idx(raw);
+    auto neighbours = Z7::neighbors(idx, DEFAULT_CONFIG);
+    std::vector<uint64_t> out(6);
+    for (int i = 0; i < 6; i++) out[i] = neighbours[i].index;
+    return val::array(out);
+}
+
+// ---------------------------------------------------------------------------
+// igeo7_get_neighbour(UBIGINT, INTEGER) → UBIGINT
+// `direction` must be 1-6; otherwise returns UINT64_MAX.
+// ---------------------------------------------------------------------------
+static uint64_t igeo7_get_neighbour(uint64_t raw, int32_t direction) {
+    if (direction < 1 || direction > 6) {
+        return std::numeric_limits<uint64_t>::max();
+    }
+    Z7::Z7Index idx(raw);
+    auto neighbours = Z7::neighbors(idx, DEFAULT_CONFIG);
+    return neighbours[static_cast<size_t>(direction - 1)].index;
+}
+
+// ---------------------------------------------------------------------------
+// igeo7_first_non_zero(UBIGINT) → INTEGER
+// ---------------------------------------------------------------------------
+static int32_t igeo7_first_non_zero(uint64_t raw) {
+    Z7::Z7Index idx(raw);
+    return static_cast<int32_t>(Z7::first_non_zero(idx));
+}
+
+// ---------------------------------------------------------------------------
+// igeo7_is_valid(UBIGINT) → BOOLEAN
+// ---------------------------------------------------------------------------
+static bool igeo7_is_valid(uint64_t raw) {
+    return raw != std::numeric_limits<uint64_t>::max();
+}
+
+// ---------------------------------------------------------------------------
+// igeo7_encode(base, d1..d20) → UBIGINT
+//
+// Pack a base cell (0-11) and exactly 20 three-bit digit slots (0-7) into
+// the canonical 64-bit Z7 index. Field values are masked internally so
+// callers do not need to range-check.
+// ---------------------------------------------------------------------------
+static uint64_t igeo7_encode(
+    int base,
+    int d1, int d2, int d3, int d4, int d5,
+    int d6, int d7, int d8, int d9, int d10,
+    int d11, int d12, int d13, int d14, int d15,
+    int d16, int d17, int d18, int d19, int d20)
+{
+    static constexpr int shifts[20] = {
+        57, 54, 51, 48, 45, 42, 39, 36, 33, 30,
+        27, 24, 21, 18, 15, 12,  9,  6,  3,  0
+    };
+    const int digits[20] = {
+        d1, d2, d3, d4, d5, d6, d7, d8, d9, d10,
+        d11, d12, d13, d14, d15, d16, d17, d18, d19, d20
+    };
+    uint64_t packed = static_cast<uint64_t>(base & 0x0F) << 60;
+    for (int k = 0; k < 20; k++) {
+        packed |= static_cast<uint64_t>(digits[k] & 0x07) << shifts[k];
+    }
+    return packed;
+}
+
+// ---------------------------------------------------------------------------
+// Bindings
+// ---------------------------------------------------------------------------
+EMSCRIPTEN_BINDINGS(igeo7_module) {
+    emscripten::function("igeo7_get_resolution", &igeo7_get_resolution);
+    emscripten::function("igeo7_get_base_cell",  &igeo7_get_base_cell);
+    emscripten::function("igeo7_get_digit",      &igeo7_get_digit);
+    emscripten::function("igeo7_parent",         &igeo7_parent);
+    emscripten::function("igeo7_parent_at",      &igeo7_parent_at);
+    emscripten::function("igeo7_to_string",      &igeo7_to_string);
+    emscripten::function("igeo7_from_string",    &igeo7_from_string);
+    emscripten::function("igeo7_get_neighbours", &igeo7_get_neighbours);
+    emscripten::function("igeo7_get_neighbour",  &igeo7_get_neighbour);
+    emscripten::function("igeo7_first_non_zero", &igeo7_first_non_zero);
+    emscripten::function("igeo7_is_valid",       &igeo7_is_valid);
+    emscripten::function("igeo7_encode",         &igeo7_encode);
+}

--- a/src-ts/webdggrid.ts
+++ b/src-ts/webdggrid.ts
@@ -2370,4 +2370,227 @@ export class Webdggrid {
     // There are no PLANE_to_* transformations available.
     // Use other coordinate systems (GEO, SEQNUM, Q2DI, Q2DD, PROJTRI) as input.
     // -------------------------------------------------------------------------
+
+    // =========================================================================
+    // IGEO7 / Z7 — hexagonal hierarchical index (packed UBIGINT)
+    //
+    // Wraps the upstream Z7 C++ core library (from allixender/igeo7_duckdb).
+    // These are **stateless** bit-level operations on a packed 64-bit index —
+    // they do **not** use the active DGGS configuration and can be called
+    // without first invoking {@link setDggs}.
+    //
+    // Index layout (MSB → LSB):
+    //   [63:60]  base cell  (0-11)
+    //   [59:57]  digit  1   (0-6; 7 = padding / unused slot)
+    //   [56:54]  digit  2
+    //   ...
+    //   [ 2: 0]  digit 20
+    //
+    // The "compact string" form from {@link igeo7ToString} is a 2-digit
+    // zero-padded base cell followed by the non-padding digit characters —
+    // e.g. `'0800432'` (base 08, digits 0,0,4,3,2, resolution 5).
+    //
+    // The invalid sentinel is `UINT64_MAX` (`0xFFFFFFFFFFFFFFFFn`), returned
+    // by {@link igeo7Neighbours} for pentagon-excluded directions and by
+    // {@link igeo7Neighbour} for out-of-range direction arguments.
+    // =========================================================================
+
+    /**
+     * Normalize a 64-bit integer (possibly returned as signed BigInt by the
+     * WASM boundary when bit 63 is set) to its canonical unsigned form.
+     * @internal
+     */
+    private _u64(x: bigint): bigint {
+        return BigInt.asUintN(64, x);
+    }
+
+    /**
+     * Parse a Z7 compact string into a packed 64-bit index.
+     *
+     * ```ts
+     * const idx = dggs.igeo7FromString('0800432');
+     * // idx is a BigInt packed index for base=8, digits=[0,0,4,3,2], res=5
+     * ```
+     *
+     * @param s - Compact Z7 string (2-digit base + digit characters).
+     * @returns Packed index as BigInt (unsigned).
+     */
+    igeo7FromString(s: string): bigint {
+        return this._u64(this._module.igeo7_from_string(s));
+    }
+
+    /**
+     * Render a packed Z7 index as its compact string form.
+     *
+     * Stops at the first padding digit (value 7), producing a string whose
+     * length reflects the cell's resolution (`2 + resolution` characters).
+     *
+     * ```ts
+     * dggs.igeo7ToString(dggs.igeo7FromString('0800432')); // '0800432'
+     * ```
+     *
+     * @param index - Packed Z7 index.
+     * @returns Compact Z7 string.
+     */
+    igeo7ToString(index: bigint): string {
+        return this._module.igeo7_to_string(index);
+    }
+
+    /**
+     * Pack a base cell and exactly 20 digit slots into a 64-bit Z7 index.
+     *
+     * Use digit value `7` for every slot beyond the desired resolution.
+     * Field values are masked internally — no range-check is required.
+     *
+     * ```ts
+     * // Reconstruct '0800432' — base=8, resolution=5
+     * const idx = dggs.igeo7Encode(
+     *   8, [0,0,4,3,2, 7,7,7,7,7, 7,7,7,7,7, 7,7,7,7,7]
+     * );
+     * // idx === dggs.igeo7FromString('0800432')
+     * ```
+     *
+     * @param base - Base cell (0-11).
+     * @param digits - Exactly 20 digit values (0-7 each).
+     * @returns Packed Z7 index as BigInt.
+     * @throws If `digits.length !== 20`.
+     */
+    igeo7Encode(base: number, digits: number[]): bigint {
+        if (digits.length !== 20) {
+            throw new Error(`igeo7Encode requires exactly 20 digits, got ${digits.length}`);
+        }
+        return this._u64(this._module.igeo7_encode(
+            base,
+            digits[0], digits[1], digits[2], digits[3], digits[4],
+            digits[5], digits[6], digits[7], digits[8], digits[9],
+            digits[10], digits[11], digits[12], digits[13], digits[14],
+            digits[15], digits[16], digits[17], digits[18], digits[19]
+        ));
+    }
+
+    /**
+     * Extract the resolution (0-20) of a packed Z7 index.
+     *
+     * @param index - Packed Z7 index.
+     * @returns Resolution level.
+     */
+    igeo7GetResolution(index: bigint): number {
+        return this._module.igeo7_get_resolution(index);
+    }
+
+    /**
+     * Extract the base cell (0-11) of a packed Z7 index.
+     *
+     * @param index - Packed Z7 index.
+     * @returns Base cell ID.
+     */
+    igeo7GetBaseCell(index: bigint): number {
+        return this._module.igeo7_get_base_cell(index);
+    }
+
+    /**
+     * Extract the `i`-th digit (1-20) of a packed Z7 index.
+     * Positions outside `[1, 20]` return `7` (matches DuckDB extension).
+     *
+     * @param index - Packed Z7 index.
+     * @param position - Digit position, 1-based.
+     * @returns Digit value (0-7).
+     */
+    igeo7GetDigit(index: bigint, position: number): number {
+        return this._module.igeo7_get_digit(index, position);
+    }
+
+    /**
+     * Parent of a Z7 cell — one hierarchy level up.
+     *
+     * At resolution 0 the cell is its own parent (the result has resolution 0
+     * and the same base cell).
+     *
+     * ```ts
+     * const child = dggs.igeo7FromString('0800432');
+     * dggs.igeo7ToString(dggs.igeo7Parent(child)); // '080043'
+     * ```
+     *
+     * @param index - Packed Z7 index.
+     * @returns Parent index as BigInt.
+     */
+    igeo7Parent(index: bigint): bigint {
+        return this._u64(this._module.igeo7_parent(index));
+    }
+
+    /**
+     * Ancestor of a Z7 cell at a specific resolution.
+     *
+     * Keeps digits `1..resolution` and fills the remainder with padding
+     * (`7`). The argument is clamped to `[0, 20]`.
+     *
+     * ```ts
+     * const cell = dggs.igeo7FromString('0800432');
+     * dggs.igeo7ToString(dggs.igeo7ParentAt(cell, 3)); // '08004'
+     * ```
+     *
+     * @param index - Packed Z7 index.
+     * @param resolution - Target resolution (0-20).
+     * @returns Ancestor index as BigInt.
+     */
+    igeo7ParentAt(index: bigint, resolution: number): bigint {
+        return this._u64(this._module.igeo7_parent_at(index, resolution));
+    }
+
+    /**
+     * Return all 6 neighbour indices of a Z7 cell, in GBT directions 1-6.
+     *
+     * Invalid neighbours (e.g. one direction on the 12 pentagons) are the
+     * sentinel `UINT64_MAX` (`0xFFFFFFFFFFFFFFFFn`). Use {@link igeo7IsValid}
+     * to filter them out.
+     *
+     * ```ts
+     * const cell = dggs.igeo7FromString('0800432');
+     * const ns = dggs.igeo7Neighbours(cell)
+     *   .filter(n => dggs.igeo7IsValid(n))
+     *   .map(n => dggs.igeo7ToString(n));
+     * ```
+     *
+     * @param index - Packed Z7 index.
+     * @returns Array of exactly 6 BigInt neighbour indices.
+     */
+    igeo7Neighbours(index: bigint): bigint[] {
+        const raw = this._module.igeo7_get_neighbours(index) as bigint[];
+        return raw.map(n => this._u64(n));
+    }
+
+    /**
+     * Single neighbour of a Z7 cell by GBT direction (1-6).
+     *
+     * Returns the invalid sentinel (`UINT64_MAX`) when `direction` is outside
+     * `[1, 6]` or when the requested neighbour is excluded (pentagons).
+     *
+     * @param index - Packed Z7 index.
+     * @param direction - Direction number, 1-6.
+     * @returns Neighbour index as BigInt.
+     */
+    igeo7Neighbour(index: bigint, direction: number): bigint {
+        return this._u64(this._module.igeo7_get_neighbour(index, direction));
+    }
+
+    /**
+     * Position (1-20) of the first non-zero digit slot in a Z7 index.
+     * Returns `0` when no non-zero digit exists (centre of the base cell).
+     *
+     * @param index - Packed Z7 index.
+     * @returns Position of first non-zero digit, or 0.
+     */
+    igeo7FirstNonZero(index: bigint): number {
+        return this._module.igeo7_first_non_zero(index);
+    }
+
+    /**
+     * Whether a packed Z7 index is valid (i.e. not the `UINT64_MAX` sentinel).
+     *
+     * @param index - Packed Z7 index.
+     * @returns `true` if valid, `false` for the invalid sentinel.
+     */
+    igeo7IsValid(index: bigint): boolean {
+        return this._module.igeo7_is_valid(index);
+    }
 }

--- a/tests/unit/igeo7.test.ts
+++ b/tests/unit/igeo7.test.ts
@@ -1,0 +1,176 @@
+import { describe, test, beforeAll, expect } from 'vitest';
+import { Webdggrid } from '../../lib-esm/webdggrid';
+
+const INVALID = 0xFFFFFFFFFFFFFFFFn; // UINT64_MAX — Z7 invalid sentinel
+
+describe('IGEO7 / Z7 bindings', () => {
+    let dggs: Webdggrid;
+
+    beforeAll(async () => {
+        dggs = await Webdggrid.load();
+    });
+
+    describe('round-trips', () => {
+        test('string ↔ packed index', () => {
+            const idx = dggs.igeo7FromString('0800432');
+            expect(typeof idx).toBe('bigint');
+            expect(dggs.igeo7ToString(idx)).toBe('0800432');
+        });
+
+        test('encode reproduces from-string', () => {
+            // Reference cell: base=8, digits=[0,0,4,3,2], res=5
+            const digits = [
+                0, 0, 4, 3, 2,
+                7, 7, 7, 7, 7,
+                7, 7, 7, 7, 7,
+                7, 7, 7, 7, 7,
+            ];
+            const fromEncode = dggs.igeo7Encode(8, digits);
+            const fromString = dggs.igeo7FromString('0800432');
+            expect(fromEncode).toBe(fromString);
+        });
+
+        test('encode rejects wrong digit count', () => {
+            expect(() => dggs.igeo7Encode(0, [0, 1, 2])).toThrow(/20 digits/);
+        });
+
+        test('known fixed-point — base 0 at resolution 13', () => {
+            // Cell id from README: 32023330408103935 → '000161612062413'
+            const cell = 32023330408103935n;
+            expect(dggs.igeo7GetBaseCell(cell)).toBe(0);
+            expect(dggs.igeo7GetResolution(cell)).toBe(13);
+            expect(dggs.igeo7ToString(cell)).toBe('000161612062413');
+
+            const encoded = dggs.igeo7Encode(0, [
+                0, 1, 6, 1, 6, 1, 2, 0, 6, 2, 4, 1, 3,
+                7, 7, 7, 7, 7, 7, 7,
+            ]);
+            expect(encoded).toBe(cell);
+        });
+    });
+
+    describe('decomposition', () => {
+        test('base cell extraction', () => {
+            expect(dggs.igeo7GetBaseCell(dggs.igeo7FromString('0800432'))).toBe(8);
+            expect(dggs.igeo7GetBaseCell(dggs.igeo7FromString('11'))).toBe(11);
+        });
+
+        test('resolution matches digit count', () => {
+            expect(dggs.igeo7GetResolution(dggs.igeo7FromString('08'))).toBe(0);
+            expect(dggs.igeo7GetResolution(dggs.igeo7FromString('0800'))).toBe(2);
+            expect(dggs.igeo7GetResolution(dggs.igeo7FromString('0800432'))).toBe(5);
+        });
+
+        test('digit extraction (1-indexed)', () => {
+            const cell = dggs.igeo7FromString('0800432');
+            expect(dggs.igeo7GetDigit(cell, 1)).toBe(0);
+            expect(dggs.igeo7GetDigit(cell, 2)).toBe(0);
+            expect(dggs.igeo7GetDigit(cell, 3)).toBe(4);
+            expect(dggs.igeo7GetDigit(cell, 4)).toBe(3);
+            expect(dggs.igeo7GetDigit(cell, 5)).toBe(2);
+            // Padding beyond resolution
+            expect(dggs.igeo7GetDigit(cell, 6)).toBe(7);
+            // Out-of-range positions return 7
+            expect(dggs.igeo7GetDigit(cell, 0)).toBe(7);
+            expect(dggs.igeo7GetDigit(cell, 21)).toBe(7);
+        });
+
+        test('first non-zero digit position', () => {
+            // '0800432' → digits 0,0,4,3,2 → first non-zero is at position 3
+            const cell = dggs.igeo7FromString('0800432');
+            expect(dggs.igeo7FirstNonZero(cell)).toBe(3);
+            // base-only cell (all digits padded) → 0
+            expect(dggs.igeo7FirstNonZero(dggs.igeo7FromString('08'))).toBe(0);
+        });
+    });
+
+    describe('hierarchy', () => {
+        test('parent drops one digit', () => {
+            const cell = dggs.igeo7FromString('0800432');
+            const parent = dggs.igeo7Parent(cell);
+            expect(dggs.igeo7ToString(parent)).toBe('080043');
+            expect(dggs.igeo7GetResolution(parent)).toBe(4);
+        });
+
+        test('parentAt truncates to target resolution', () => {
+            const cell = dggs.igeo7FromString('0800432');
+            expect(dggs.igeo7ToString(dggs.igeo7ParentAt(cell, 3))).toBe('08004');
+            expect(dggs.igeo7ToString(dggs.igeo7ParentAt(cell, 5))).toBe('0800432');
+            // Clamps low and high
+            expect(dggs.igeo7GetResolution(dggs.igeo7ParentAt(cell, -1))).toBe(0);
+            expect(dggs.igeo7GetResolution(dggs.igeo7ParentAt(cell, 99))).toBeLessThanOrEqual(20);
+        });
+
+        test('parent at res 0 equals root', () => {
+            const cell = dggs.igeo7FromString('0800432');
+            const root = dggs.igeo7ParentAt(cell, 0);
+            expect(dggs.igeo7GetResolution(root)).toBe(0);
+            expect(dggs.igeo7GetBaseCell(root)).toBe(8);
+        });
+
+        test('recursive walk up to resolution 0', () => {
+            let cell = dggs.igeo7FromString('0800432');
+            const path: string[] = [dggs.igeo7ToString(cell)];
+            while (dggs.igeo7GetResolution(cell) > 0) {
+                cell = dggs.igeo7Parent(cell);
+                path.push(dggs.igeo7ToString(cell));
+            }
+            expect(path).toEqual([
+                '0800432',
+                '080043',
+                '08004',
+                '0800',
+                '080',
+                '08',
+            ]);
+        });
+    });
+
+    describe('neighbours', () => {
+        test('returns exactly 6 entries', () => {
+            const cell = dggs.igeo7FromString('0800432');
+            const ns = dggs.igeo7Neighbours(cell);
+            expect(ns).toHaveLength(6);
+            ns.forEach(n => expect(typeof n).toBe('bigint'));
+        });
+
+        test('single-neighbour lookup matches array lookup', () => {
+            const cell = dggs.igeo7FromString('0800432');
+            const all = dggs.igeo7Neighbours(cell);
+            for (let dir = 1; dir <= 6; dir++) {
+                expect(dggs.igeo7Neighbour(cell, dir)).toBe(all[dir - 1]);
+            }
+        });
+
+        test('invalid direction yields invalid sentinel', () => {
+            const cell = dggs.igeo7FromString('0800432');
+            expect(dggs.igeo7Neighbour(cell, 0)).toBe(INVALID);
+            expect(dggs.igeo7Neighbour(cell, 7)).toBe(INVALID);
+            expect(dggs.igeo7Neighbour(cell, -1)).toBe(INVALID);
+        });
+
+        test('pentagon (base cell 0 at res 2) has exactly one invalid neighbour', () => {
+            // At '0800' the digits are all zero → pentagon case: direction 5
+            // is excluded per exclusion_zone[0] = 2? Actually exclusion_zone[0]
+            // is 2, so direction 2 is excluded. Regardless of which: exactly
+            // one of the six is invalid.
+            const pent = dggs.igeo7FromString('0800');
+            const ns = dggs.igeo7Neighbours(pent);
+            const invalidCount = ns.filter(n => !dggs.igeo7IsValid(n)).length;
+            expect(invalidCount).toBe(1);
+        });
+
+        test('non-pentagon cell has all 6 neighbours valid', () => {
+            const cell = dggs.igeo7FromString('0800432');
+            const ns = dggs.igeo7Neighbours(cell);
+            ns.forEach(n => expect(dggs.igeo7IsValid(n)).toBe(true));
+        });
+    });
+
+    describe('validity sentinel', () => {
+        test('isValid true for normal cells, false for sentinel', () => {
+            expect(dggs.igeo7IsValid(dggs.igeo7FromString('0800432'))).toBe(true);
+            expect(dggs.igeo7IsValid(INVALID)).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
Introduce IGEO7/Z7 hexagonal hierarchical index support, including Emscripten bindings, a Vue component for an interactive demo, and comprehensive documentation. Integrate the igeo7_duckdb submodule to enhance functionality.